### PR TITLE
Clean up Candidate C governance and programme-map language

### DIFF
--- a/docs/clay-problem-programme-map.md
+++ b/docs/clay-problem-programme-map.md
@@ -1,13 +1,13 @@
 # The Clay Problem and the Programme Map
 
-**Subtitle:** Where the Heller–Winters Construction Sits Among Approaches to the Riemann Hypothesis  
+**Subtitle:** Where the Heller–Winters Programme Sits Among Approaches to the Riemann Hypothesis  
 **Section:** Problem Statement and Related Work  
 **Draft date:** 2026-05-09  
-**Status:** scaffolded — neutral with respect to the eventual statement of the Heller–Winters Theorem
+**Status:** scaffolded — neutral with respect to future Heller–Winters theorem-candidate statements
 
 ## 1. The Clay Problem
 
-### 1.1 Riemann’s Setup
+### 1.1 Riemann’s setup
 
 The Riemann zeta function is defined on the half-plane `Re(s) > 1` by the absolutely convergent Dirichlet series
 
@@ -15,173 +15,172 @@ The Riemann zeta function is defined on the half-plane `Re(s) > 1` by the absolu
 \zeta(s) = \sum_{n=1}^{\infty} \frac{1}{n^s},
 ```
 
-and is extended to all of `C` by analytic continuation. Riemann's 1859 memoir established that `\zeta(s)` is meromorphic on `C` with a simple pole at `s = 1` of residue `1`, and that it satisfies a functional equation expressing the symmetry `s <-> 1 - s` around the critical line `Re(s) = 1/2`.
+and is extended to all of `C` by analytic continuation. Riemann’s 1859 memoir established that `\zeta(s)` is meromorphic on `C` with a simple pole at `s = 1` of residue `1`, and that it satisfies a functional equation expressing the symmetry `s <-> 1-s` around the critical line `Re(s) = 1/2`.
 
 The trivial zeros occur at the negative even integers `-2, -4, -6, ...`. All other zeros lie in the critical strip `0 <= Re(s) <= 1` and are called nontrivial zeros.
 
-Following Riemann, one packages the functional-equation symmetry into the entire xi function. Under the normalization `s = 1/2 + it`, the nontrivial zeros of `\zeta(s)` correspond exactly to the zeros of `\xi(t)`. The Riemann Hypothesis is therefore equivalent to the assertion that all zeros of this even entire function are real.
+Following Riemann, the functional-equation symmetry can be packaged into the entire xi function. Under the normalization `s = 1/2 + it`, the nontrivial zeros of `\zeta(s)` correspond exactly to zeros of `\xi(t)`. RH is therefore equivalent to the assertion that all zeros of this even entire function are real.
 
-### 1.2 The Official Statement
+### 1.2 Official statement
 
-The Riemann Hypothesis, in the Clay Mathematics Institute formulation, asserts:
+The Riemann Hypothesis asserts:
 
 > The nontrivial zeros of `\zeta(s)` have real part equal to `1/2`.
 
 Equivalently, all zeros of `\xi(t)` are real. The Clay Millennium Prize problem asks for a proof or disproof of this statement.
 
-### 1.3 Equivalent Formulations
+### 1.3 Equivalent formulations
 
-The Riemann Hypothesis admits several reformulations. Each is logically equivalent to the standard zero-locus statement and surfaces a different mathematical structure.
+The Riemann Hypothesis admits several logically equivalent reformulations:
 
 **R1. Zero locus.** All nontrivial zeros of `\zeta(s)` satisfy `Re(s) = 1/2`.
 
-**R2. Prime-counting error term.** RH is equivalent to the sharp square-root-scale control of the deviation of `\pi(x)` from `Li(x)`:
+**R2. Prime-counting error term.** RH is equivalent to square-root-scale control of the deviation of `\pi(x)` from `Li(x)`:
 
 ```math
 \pi(x) = \operatorname{Li}(x) + O(\sqrt{x}\log x).
 ```
 
-This is the form most directly relevant to prime distribution.
-
-**R3. Chebyshev / von Mangoldt form.** With `\Lambda(n)` the von Mangoldt function and `\psi(x) = \sum_{n \le x} \Lambda(n)`, RH is equivalent to
+**R3. Chebyshev / von Mangoldt form.** With `\Lambda(n)` the von Mangoldt function and `\psi(x)=\sum_{n \le x}\Lambda(n)`, RH is equivalent to
 
 ```math
 \psi(x) = x + O(\sqrt{x}\log^2 x).
 ```
 
-This form is analytically natural because `\psi` is the Mellin counterpart of `-\zeta'/\zeta`.
+**R4. Real zeros of xi.** All zeros of the entire function `\xi(t)` are real. This form connects most directly to Hilbert–Pólya and spectral programmes.
 
-**R4. Real zeros of xi.** All zeros of the entire function `\xi(t)` are real. This is the form connected most directly to Hilbert–Pólya and spectral programmes.
-
-**R5. Robin-type and elementary criteria.** RH is equivalent to sharp inequalities for classical arithmetic functions, including Robin's divisor-sum criterion for `n >= 5041`:
+**R5. Robin-type and elementary criteria.** RH is equivalent to sharp inequalities for classical arithmetic functions, including Robin’s divisor-sum criterion for `n >= 5041`:
 
 ```math
 \sigma(n) < e^\gamma n \log\log n.
 ```
 
-The reformulations are not separate theorems. They are different coordinate systems on one problem.
+These are different coordinate systems on one problem, not separate problems.
 
 ### 1.4 Generalization to L-functions
 
-The zeta function is the prototype for a broader class of L-functions. Modern analytic number theory treats RH as one instance of a larger family of Riemann-hypothesis-type conjectures.
+The zeta function is the prototype for broader classes of L-functions. Modern analytic number theory often treats RH as one instance of a larger family of Riemann-hypothesis-type conjectures.
 
 **Dirichlet L-functions.** For a Dirichlet character `\chi` modulo `q`, the function
 
 ```math
-L(s, \chi) = \sum_{n=1}^{\infty} \frac{\chi(n)}{n^s}
+L(s,\chi)=\sum_{n=1}^{\infty}\frac{\chi(n)}{n^s}
 ```
 
-has its own functional equation. GRH asserts that all nontrivial zeros of every such `L(s, \chi)` lie on `Re(s) = 1/2`.
+has its own functional equation. GRH asserts that the nontrivial zeros of these L-functions lie on `Re(s)=1/2`.
 
-**Automorphic L-functions.** For automorphic representations of `GL_n`, the corresponding L-functions are expected to satisfy functional equations and Riemann-hypothesis-type zero-location statements.
+**Automorphic L-functions.** Automorphic L-functions are expected to satisfy functional equations and analogous Riemann-hypothesis-type zero-location statements.
 
-**Zeta functions over finite fields.** The finite-field analogues are proved: Hasse for elliptic curves, Weil for curves, and Deligne for smooth projective varieties. The geometric proof via cohomology remains a central model for what a proof over `Spec Z` might require.
+**Zeta functions over finite fields.** The finite-field analogues are proved: Hasse for elliptic curves, Weil for curves, and Deligne for smooth projective varieties. These results shape the modern intuition that a proof over arithmetic geometry might require a replacement cohomological or spectral structure.
 
-In this repository, `RH` denotes the classical Riemann Hypothesis for `\zeta`, `GRH` denotes the Dirichlet/generalized variants when specified, and broader L-function hypotheses are named explicitly.
+In this repository, `RH` denotes the classical Riemann Hypothesis for `\zeta`, `GRH` denotes generalized variants when specified, and broader L-function hypotheses are named explicitly.
 
-## 2. What Is Known
+## 2. What is known
 
-### 2.1 Computational Verification
+RH remains open, but it is surrounded by extensive partial results and evidence.
 
-Computational verification combines exact zero counts from the argument principle with sign-change detection for `\xi(t)` on the real axis. If the contour count matches the number of detected critical-line zeros, all zeros in the searched range are on the line.
+### 2.1 Computational verification
 
-Known milestones include verification of the first 1.5 billion zeros by van de Lune, te Riele, and Winter; Odlyzko's high-height computations; and later large-scale verification campaigns reaching very high initial zero counts. These computations do not prove RH, but they sharply constrain any counterexample and support the observed random-matrix statistics of the zeros.
+Computational verification combines exact zero counts from the argument principle with sign-change detection for `\xi(t)` on the real axis. These computations verify finitely many zeros and therefore cannot prove RH, but they sharply constrain any counterexample and support the observed statistical regularities of zeta zeros.
 
-### 2.2 Critical-Line Theorems
+### 2.2 Critical-line theorems
 
-Hardy proved that infinitely many zeros lie on the critical line. Selberg proved a positive proportion. Levinson improved this to more than one third, and Conrey to more than two fifths. These results are strong but still fall short of proving that all nontrivial zeros lie on the line.
+Hardy proved infinitely many zeros lie on the critical line. Selberg proved a positive proportion. Levinson improved this to more than one third, and Conrey to more than two fifths. These results are strong but remain far from proving that all nontrivial zeros lie on the line.
 
-### 2.3 Density Theorems
+### 2.3 Density theorems
 
-Zero-density theorems bound how many zeros may lie to the right of a vertical line `Re(s) = alpha > 1/2`. RH asserts that this count is zero for every `alpha > 1/2`. Existing density theorems show that exceptions, if they exist, are rare and distributionally constrained.
+Zero-density theorems bound how many zeros may lie to the right of a vertical line `Re(s)=alpha>1/2`. RH asserts that this count is zero for every `alpha>1/2`; existing theorems show that exceptions, if they exist, are constrained.
 
-### 2.4 Sieve Programme and Bounded Gaps
+### 2.4 Sieve programme and bounded gaps
 
-The sieve tradition attacks prime-distribution consequences directly. Bombieri–Vinogradov gives GRH-strength control on average over moduli. The GPY, Zhang, Maynard, and Polymath bounded-gap results show that a properly engineered stack of sieve, average-distribution, and combinatorial bounds can extract sharp arithmetic information without resolving RH.
+The sieve tradition attacks prime-distribution consequences directly. Bombieri–Vinogradov gives GRH-strength control on average over moduli. The GPY, Zhang, Maynard, and Polymath bounded-gap results show that well-engineered sieve, average-distribution, and combinatorial stacks can extract sharp arithmetic information without resolving RH.
 
-This posture is important for Heller–Winters: the construction is allowed to produce auditable, distributional, envelope, and residual-control results even before any claim to RH proper exists.
+This posture matters for Heller–Winters: the programme may produce auditable finite-window, distributional, envelope, or residual-control artifacts without claiming RH.
 
-## 3. Programmes of Attack
+## 3. Programmes of attack
 
-### 3.1 Zero-Density and Mean-Value Methods
+### 3.1 Zero-density and mean-value methods
 
-This programme works directly with the zero locus and seeks to drive density estimates toward `N(alpha, T) = 0` for all `alpha > 1/2`. It uses mean-value estimates, large-sieve inequalities, and zero-detection methods.
+This programme works directly with the zero locus and seeks to drive density estimates toward `N(alpha,T)=0` for all `alpha>1/2`. It uses mean-value estimates, large-sieve inequalities, and zero-detection methods.
 
-### 3.2 Hilbert–Pólya: The Spectral Programme
+### 3.2 Hilbert–Pólya and spectral programmes
 
-Hilbert–Pólya proposes that the zeros of `\xi(t)` are eigenvalues of a self-adjoint operator. If such an operator were constructed with the correct spectrum, RH would follow from self-adjointness. Berry–Keating and Connes are central modern representatives of this spectral line.
+Hilbert–Pólya proposes that zeros of `\xi(t)` arise as eigenvalues of a self-adjoint operator. A correct construction would imply RH by self-adjointness. Berry–Keating and Connes are representative modern spectral lines, but no such completed operator proof exists.
 
-### 3.3 Random Matrix Theory and Spacing Statistics
+### 3.3 Random matrix theory and spacing statistics
 
-Montgomery's pair-correlation work and Odlyzko's computations connect the statistics of zeta zeros with GUE eigenvalue statistics. Katz–Sarnak proved analogous statements in finite-field families. This programme supplies strong evidence and predictions, but not by itself a proof of zero location.
+Montgomery’s pair-correlation work, Odlyzko’s computations, and Katz–Sarnak’s finite-field results connect zero statistics with random-matrix ensembles. This supplies evidence and prediction, but not by itself a proof of zero location.
 
-### 3.4 Algebraic-Geometric Analogy
+### 3.4 Algebraic-geometric analogy
 
-The finite-field RH proof routes through cohomology and Frobenius eigenvalues. The classical open problem is whether an analogous cohomological theory exists for the zeta function over arithmetic geometry. Connes, Deninger, Haran, and related programmes can be read as attempts to construct such a replacement geometry.
+The finite-field RH proof routes through cohomology and Frobenius eigenvalues. The classical open problem is whether an analogous structure exists for the zeta function over arithmetic geometry. Connes, Deninger, Haran, and related programmes can be read as attempts to build such a replacement structure.
 
-### 3.5 Explicit Formula and Weil Positivity
+### 3.5 Explicit formula and Weil positivity
 
-The explicit formula expresses prime-side sums in terms of zero-side sums. Weil's criterion translates RH into a positivity/negativity statement for a bilinear form on a suitable test-function space. This criterion is equivalent to RH and gives a target for any proof architecture.
+The explicit formula expresses prime-side sums in terms of zero-side sums. Weil’s criterion translates RH into a positivity/negativity statement for a bilinear form. It is equivalent to RH and therefore provides a target, not an independent proof.
 
-### 3.6 Elementary and Combinatorial Approaches
+### 3.6 Elementary and combinatorial approaches
 
-Robin, Lagarias, Nicolas, and related criteria show that RH can be encoded as sharp inequalities on elementary arithmetic functions. These approaches differ from sieve theory: sieve theory gives average distribution and combinatorial distributional results, while elementary RH-equivalent criteria target exact constants and inequalities.
+Robin, Lagarias, Nicolas, and related criteria encode RH as sharp inequalities on elementary arithmetic functions. These approaches differ from sieve theory: sieve theory targets average distribution, while RH-equivalent inequalities target exact constants and bounds.
 
-## 4. Where the Heller–Winters Construction Sits
+## 4. Where the Heller–Winters Programme sits
 
-The Heller–Winters construction is not an independent sixth programme. It is a unified tool layer that imports machinery from the existing programmes and assembles them into an auditable operator stack through the Proof Fabric Kernel (PFK).
+The Heller–Winters Programme is not an independent sixth proof programme for RH. It is a research programme and tool layer that imports machinery from the existing traditions and assembles them into an auditable operator stack through Proof Fabric Kernel discipline.
 
-The contribution is structural. It provides a substrate in which sieve operations, spectral measurements, explicit-formula evaluations, combinatorial certificates, and empirical falsification protocols can be composed, audited, and replayed.
+The current contribution is structural: a substrate in which sieve operations, spectral measurements, explicit-formula evaluations, combinatorial certificates, empirical falsification protocols, and provenance receipts can be composed, audited, and replayed.
 
-### 4.1 What the Construction Imports
+### 4.1 What the programme imports
 
 From the sieve programme, Heller–Winters imports wheel-sieve apparatus, symmetric-offset algebra, shell certificates, figurate scaffolds, and multi-encoding compartmentalization.
 
-From mean-value and boundedness methods, it imports Bertrand–Chebyshev enclosures, `(p, 2p)` specialization, and quotient normalization machinery.
+From mean-value and boundedness methods, it imports Bertrand–Chebyshev enclosures, `(p,2p)` specialization, and quotient normalization machinery.
 
-From the spectral programme, it imports the canonical coordinate `u = ln x`, log-harmonic decomposition, cosine phase-gate operators, and RH-consistent envelope constraints as policy lenses, not proof claims.
+From spectral programmes, it imports the canonical coordinate `u=ln x`, log-harmonic decomposition, phase-gate operators, and RH-consistent envelope constraints as policy lenses, not proof claims.
 
-From the explicit formula, it imports the `\psi`-residual decomposition and the zero-side / prime-side bridge. This is where any eventual RH-relevant proof obligation becomes load-bearing.
+From the explicit formula, it imports residual decompositions such as `\psi(x)-x` and the zero-side / prime-side bridge. This is where any future RH-relevant proof obligation would become load-bearing.
 
-From algebraic geometry, it imports lattice-counting and Ehrhart-module formalisms as exact counting substrate for wheel-admissible regions and distributional skew definitions.
+From algebraic geometry and discrete geometry, it imports lattice-counting and Ehrhart-style formalisms as possible exact-counting substrates.
 
-From statistics and falsification practice, it imports null models, stress tests, and reproducibility protocols.
+From statistics and falsification practice, it imports null models, stress tests, fixture replay, and provenance protocols.
 
-### 4.2 What the Construction Adds
+### 4.2 What the programme adds
 
-First, a compositional operator stack in which sieve, spectral, explicit-formula, and combinatorial operations can be typed and composed without category error.
+First, a compositional operator stack in which sieve, spectral, explicit-formula, empirical, and combinatorial operations can be typed and composed without category error.
 
-Second, the Proof Fabric Kernel: every output becomes a typed artifact with declared invariants, provenance, replay semantics, and claim classification.
+Second, an auditable proof-fabric discipline: every output should be a typed artifact with declared invariants, provenance, replay semantics, and claim classification.
 
-Third, a policy-operator framing of classical theorems. Euclid, Dirichlet, Chebyshev, Wilson, and adjacent theorems are represented as composable operators with explicit invariants and falsifiers. This is methodological and infrastructural; it does not by itself create new theorems.
+Third, a policy-operator framing of classical theorems and empirical operations. This is methodological and infrastructural; it does not itself produce a new theorem.
 
-### 4.3 What the Construction Does Not Yet Claim
+### 4.3 What the programme does not yet claim
 
 This repository must preserve a hard boundary between:
 
 - **Proven results:** imported classical theorems and any new theorem actually proved.
-- **Definitional structures:** the operator stack, constraint algebra, and PFK provenance schema.
-- **Empirical regularities:** phase-gate measurements, PrimeStats outputs, and falsification findings.
-- **Conjectural statements:** the Heller–Winters Theorem until it is actually stated and proved.
+- **Definitional structures:** operator definitions, registries, schemas, and provenance formats.
+- **Empirical regularities:** finite-window measurements, phase-gate outputs, null-model results, and replay artifacts.
+- **Conjectural statements:** proposed mathematical statements not yet proved.
+- **Programmatic commitments:** research directions, theorem-candidate tracks, and scale-limit obligations.
 
-The manuscript is presently a tool layer. The central theorem is still under formulation. The expected theorem shape is:
+The programme is presently a tool and research substrate. No Heller–Winters theorem is currently committed, stated, or proved.
 
-1. An envelope constraint on a residual such as `R(x) = \pi(x) - Li(x)`, `\psi(x) - x`, or a windowed quotient analogue in log coordinate `u = ln x`.
-2. A distributional skew result: a bound on a declared moment functional of the residual against an explicit null model.
-3. PFK auditability: every proof step traces to typed operators with declared invariants and reproducibility contracts.
+A future theorem-candidate track may take the form of:
 
-These describe the intended theorem form, not the theorem itself. The honest current claim is that the manuscript constructs tooling and exposes empirical regularities. Whether the final result reaches RH, GRH, a partial L-function result, or a non-RH envelope theorem is to be determined by what the operator stack can actually prove.
+1. an envelope constraint on a residual such as `R(x)=\pi(x)-Li(x)`, `\psi(x)-x`, or a windowed quotient analogue in log coordinate `u=ln x`;
+2. a distributional skew or moment-functional statement against a declared null model;
+3. an auditable proof chain through typed operators with declared invariants and replayable artifacts.
+
+These describe possible theorem-candidate shapes, not an existing theorem. Whether any future result reaches RH, GRH, a partial L-function result, or a non-RH envelope theorem is to be determined by what the operator stack can actually prove.
 
 ### 4.4 Roadmap
 
 Part I develops the historical genealogy of constraints and prime-distribution machinery. Part II develops the technical operator stack: foundations, sieve/lattice operators, normalization and calibration, ratio/harmonic apparatus, RH-consistent envelopes, phase gates, structural sieves, policy operators, evidence ledgers, and consolidated specifications.
 
-The eventual theorem statement should appear at the end of Chapter 1, with proof obligations distributed through Part II and audited by the Chapter 22 protocol. Until then, this document is the public positioning map: what the work imports, what it adds, and what it does not yet claim.
+When a theorem-candidate statement is ready, it should appear at the end of Chapter 1 with proof obligations distributed through Part II and audited by the empirical/proof protocol. Until then, this document is the public positioning map: what the programme imports, what it adds, and what it does not yet claim.
 
 ## Reference anchors
 
-Primary anchors for the section include Riemann (1859), Bombieri's Clay problem statement, Titchmarsh–Heath-Brown, Ivić, Iwaniec–Kowalski, Iwaniec–Sarnak, Hardy, Selberg, Levinson, Conrey, Bombieri–Vinogradov, GPY, Zhang, Maynard, Polymath, Montgomery, Odlyzko, Katz–Sarnak, Connes, Deninger, Haran, Weil, Bombieri–Lagarias, Yoshida, Robin, Lagarias, Beck–Robins, Deligne, Hasse, and Weil.
+Primary anchors for the section include Riemann (1859), Bombieri’s Clay problem statement, Titchmarsh–Heath-Brown, Ivić, Iwaniec–Kowalski, Iwaniec–Sarnak, Hardy, Selberg, Levinson, Conrey, Bombieri–Vinogradov, GPY, Zhang, Maynard, Polymath, Montgomery, Odlyzko, Katz–Sarnak, Connes, Deninger, Haran, Weil, Bombieri–Lagarias, Yoshida, Robin, Lagarias, Beck–Robins, Deligne, Hasse, and Weil.
 
 ## Integration note
 
-This file was added from the 2026-05-09 scaffold document `01-clay-problem-programme-map.pdf`. It is intentionally neutral with respect to the final statement of the Heller–Winters Theorem and should be treated as a manuscript/source-positioning artifact, not as a proof of RH or GRH.
+This file was added from the 2026-05-09 scaffold document `01-clay-problem-programme-map.pdf`. It is intentionally neutral with respect to future theorem-candidate statements and should be treated as a manuscript/source-positioning artifact, not as a proof of RH or GRH, and not as evidence that a Heller–Winters theorem already exists.

--- a/docs/review-gap-register.md
+++ b/docs/review-gap-register.md
@@ -2,7 +2,7 @@
 
 Status: live.  
 Review date: 2026-05-10.  
-Scope: Heller–Winters Programme repository after programme reframing and Candidate C scaffolding.
+Scope: Heller–Winters Programme repository after programme reframing and Candidate C capture.
 
 This register captures the gaps identified in the review pass and records how each gap is being discharged.
 
@@ -24,17 +24,17 @@ Status: mitigated; full discharge requires repository rename or permanent reposi
 
 ## G-03 — Programme-map theorem-language drift
 
-Risk: `docs/clay-problem-programme-map.md` still contains phrases such as “central theorem” and “Heller–Winters Theorem.”
+Risk: `docs/clay-problem-programme-map.md` contained phrases such as “central theorem” and “Heller–Winters Theorem.”
 
-Disposition: `tools/patch_programme_language.py` applies targeted replacements so the file refers to theorem candidates and future theorem-worthy results rather than an existing central theorem.
+Disposition: the programme-map has been patched to refer to the Heller–Winters Programme and to future theorem-candidate statements rather than an existing central theorem.
 
-Status: patch prepared; discharge after patch script is run and diff reviewed.
+Status: discharged by governance cleanup PR.
 
 ## G-04 — Candidate C package missing required files
 
 Risk: the package README named `run-plan.md`, `claim-ledger-entry.md`, and `pfk-receipt-template.json`, but those files were absent.
 
-Disposition: all three are supplied in this capture pack.
+Disposition: all three are supplied in the Candidate C capture.
 
 Status: discharged by file creation.
 
@@ -58,9 +58,9 @@ Status: discharged for executable v0.1.
 
 Risk: Wγ was specified but not executed.
 
-Disposition: fixture result for `X_fixture = 1e4`, `B = 16`, and seed `20260510` is included under `results/fixture/`.
+Disposition: fixture result for `X_fixture = 1e4`, `B = 16`, and seed `20260510` is included under `results/fixture/`; hosted CI replay passed.
 
-Status: fixture executed locally and captured; independent replay still owed.
+Status: discharged for fixture replay; larger-run replay remains separate work.
 
 ## G-08 — PFK was referenced but not integrated
 
@@ -92,7 +92,7 @@ Risk: Candidate C may be known, a restatement, an empirical illustration, or a g
 
 Disposition: `claim-ledger-entry.md` records literature status as pending and blocks theorem promotion.
 
-Status: open.
+Status: open; tracked by issue #27.
 
 ## G-12 — Code layer absent
 
@@ -100,15 +100,15 @@ Risk: no deterministic runner, fixture harness, surrogate generator, statistic i
 
 Disposition: `scripts/run_phase_gate_candidate_c.py` and `tests/test_phase_gate_candidate_c.py` are supplied.
 
-Status: discharged for v0.1 fixture and preliminary `X = 1e6` execution; independent replay still owed.
+Status: discharged for v0.1 fixture and preliminary `X = 1e6` execution.
 
 ## G-13 — Direct-to-main commits are inconsistent with audit discipline
 
 Risk: prior changes were committed directly to `main`.
 
-Disposition: future work should use branch + PR + review checklist. This capture pack includes a CI workflow and can be committed on a branch.
+Disposition: Candidate C capture and governance cleanup are handled by branch + PR + CI.
 
-Status: captured; process change required.
+Status: mitigated for current work; future work must keep branch/PR discipline.
 
 ## G-14 — Candidate C v0.1 does not currently show Cramér-surrogate rejection
 
@@ -116,4 +116,12 @@ Risk: the first executable statistic may not distinguish primes from a density-m
 
 Disposition: the artifact reports the negative/ambiguous result rather than inflating claims. This is a successful governance outcome: the apparatus produced a finite-window result without promotion.
 
-Status: captured; next work is statistic refinement or acceptance of negative result.
+Status: captured; tracked by issues #29 and #30.
+
+## G-15 — X1e6 preliminary raw JSON policy
+
+Risk: preliminary `X=1e6` summary and receipt existed without explicit policy for full raw JSON.
+
+Disposition: `results/X1e6-preliminary/README.md` records the decision to treat the full raw JSON as regenerable-only until the stronger B=256 run supersedes it.
+
+Status: discharged by governance cleanup PR.

--- a/empirical-claims/phase-gate-null-X1e6/results/X1e6-preliminary/README.md
+++ b/empirical-claims/phase-gate-null-X1e6/results/X1e6-preliminary/README.md
@@ -1,0 +1,39 @@
+# X1e6 Preliminary Artifact Policy
+
+Status: preliminary finite-window empirical run.  
+Registry: `phase-gate-v0.1`.  
+Claim class: empirical.
+
+## Policy decision
+
+The full raw `phase_gate_results.json` for this preliminary `X=1_000_000`, `B=16` run is treated as **regenerable-only** rather than committed as canonical raw data.
+
+The committed canonical artifacts for this preliminary run are:
+
+- `summary.md`
+- `pfk_receipt.json`
+
+The full raw JSON is reproducible from the runner and the deterministic receipt hash below.
+
+## Regeneration command
+
+```bash
+python3 scripts/run_phase_gate_candidate_c.py \
+  --x 1000000 \
+  --replicates 16 \
+  --artifact-dir empirical-claims/phase-gate-null-X1e6/results/X1e6-preliminary-regenerated
+```
+
+## Expected deterministic hash
+
+```text
+729da4e129e6f76b61bcb109629490d566468ec3387db71a80fb66edfb023105
+```
+
+## Rationale
+
+This run is preliminary. The fixture raw JSON is committed and remains the canonical replay anchor. The `X=1e6` run will be superseded by a stronger control run under issue #29 with higher Monte Carlo depth. Until then, the correct policy is to preserve the summary, receipt, regeneration command, and expected hash without pretending the preliminary raw output is final.
+
+## Non-claim boundary
+
+This artifact does not claim RH, GRH, an asymptotic theorem, zero-location control, residual-envelope control, or novelty.


### PR DESCRIPTION
## Summary

This PR performs the governance cleanup after the Candidate C executable artifact merge.

It does three things:

1. Patches `docs/clay-problem-programme-map.md` so it no longer treats a central Heller–Winters theorem as already existing.
2. Documents the `X=1e6` preliminary artifact policy: full raw JSON is regenerable-only until the stronger B=256 run supersedes it.
3. Updates `docs/review-gap-register.md` to mark G-03, fixture replay, and X1e6 policy status accurately.

## Candidate C reminder

Candidate C remains empirical. Registry v0.1 does not reject the Cramér-Bernoulli surrogate at `B=16`. This PR does not refine the statistic, rerun Monte Carlo, or promote the claim.

## Non-claim boundary

This PR does not claim RH, GRH, an asymptotic theorem, zero-location control, residual-envelope control, or novelty.

## Follow-up work

- #27 literature status review.
- #28 native PFK/Event-IR integration.
- #29 stronger B=256 null-model controls.
- #30 decide registry v0.2 or accept v0.1 as negative artifact.
