### PR TITLE
Add log-volume and arithmetic volumetric benchmark v0.1

### DIFF
--- a/.github/workflows/arithmetic-volumetric-benchmark.yml
+++ b/.github/workflows/arithmetic-volumetric-benchmark.yml
@@ -1,0 +1,16 @@
+name: arithmetic-volumetric-benchmark
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python3 scripts/check_arithmetic_volumetric_benchmark.py
+      - run: python3 -m unittest discover -s tests -p test_arithmetic_volumetric_benchmark.py

--- a/.github/workflows/log-volume-normalization.yml
+++ b/.github/workflows/log-volume-normalization.yml
@@ -1,0 +1,16 @@
+name: log-volume-normalization
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python3 scripts/check_log_volume_normalization.py
+      - run: python3 -m unittest discover -s tests -p test_log_volume_normalization.py

--- a/docs/specs/arithmetic-volumetric-benchmark-v0.1.md
+++ b/docs/specs/arithmetic-volumetric-benchmark-v0.1.md
@@ -1,0 +1,39 @@
+# Arithmetic Volumetric Benchmark v0.1
+
+Status: definitional / empirical-harness benchmark. Claim class: definitional.
+
+This specification defines a two-axis arithmetic benchmark surface inspired by quantum-volume methodology. It is a benchmarking analogy only, not quantum volume and not a quantum hardware claim.
+
+## Axes
+
+The surface is indexed by:
+
+```text
+u = logarithmic scale location
+L = multiplicative window width
+Score(u,L) = finite-window benchmark score
+```
+
+The canonical window is inherited from Prime Log-Volume Spectral Normalization v0.1:
+
+```text
+W(u,L) = [exp(u), exp(u+L)]
+```
+
+A compliant artifact must keep the two-axis surface explicit and must not collapse it to one scalar unless a scalarization rule is declared.
+
+## Quantum-volume relation
+
+Quantum volume asks how much circuit width/depth can be executed before noise destroys useful signal. Arithmetic volumetric benchmarking asks how much multiplicative arithmetic window structure remains after canonical mean-field subtraction and residual normalization.
+
+The analogy map is:
+
+```text
+quantum width/depth        -> arithmetic u/L surface
+hardware noise            -> density drift and normalization error
+successful circuit volume -> replayable residual signal volume
+```
+
+## Claim boundary
+
+This is not equivalent to quantum volume. It is not a quantum hardware benchmark, not a quantum advantage claim, and not an RH/GRH claim. Any later mapping to quantum circuits requires a separate compiler/runtime artifact.

--- a/docs/specs/prime-log-volume-spectral-normalization-v0.1.md
+++ b/docs/specs/prime-log-volume-spectral-normalization-v0.1.md
@@ -1,0 +1,50 @@
+# Prime Log-Volume Spectral Normalization v0.1
+
+Status: definitional / empirical-harness normalization. Claim class: definitional.
+
+This specification locks the coordinate, window, mean-field, residual, and claim-boundary conventions for finite-window prime-distribution experiments in the Heller-Winters Programme.
+
+## Coordinate and window
+
+The canonical coordinate is `u = ln(x)`, so `x = exp(u)` and `dx = exp(u) du`. A fixed increment `L` in `u` is a multiplicative window in `x`:
+
+```text
+W(u,L) = [exp(u), exp(u+L)]
+```
+
+Other bases are display gauges only. If `log_b(x) = ln(x)/ln(b)`, then `gamma_b = gamma ln(b)` preserves `cos(gamma ln x)`.
+
+## Mean field
+
+For prime-count windows, use:
+
+```text
+MF_count(u,L) = Li(exp(u+L)) - Li(exp(u))
+              = integral_u_to_u+L exp(v)/v dv
+```
+
+The leading approximation is `exp(u)/u * (exp(L)-1)`. Finite-window checks must preserve the first deterministic correction:
+
+```text
+-exp(u)/u^2 * ((L-1) exp(L) + 1)
+```
+
+## Residual channels
+
+Prime-count residual:
+
+```text
+R_count(u,L) = pi(exp(u+L)) - pi(exp(u)) - MF_count(u,L)
+```
+
+Chebyshev residual:
+
+```text
+R_psi(u,L) = psi(exp(u+L)) - psi(exp(u)) - (exp(u+L)-exp(u))
+```
+
+The Chebyshev channel is the direct `exp(u/2)` envelope channel. Prime-count residuals require their own declared normalization because the explicit-formula terms pass through `Li(exp(rho u))`.
+
+## Claim boundary
+
+This is not a theorem-promotion artifact. It does not claim RH, GRH, deterministic primality, zero-location results, or asymptotic speedup. It only defines a replayable normalization contract.

--- a/empirical-claims/arithmetic-volumetric-benchmark-v0.1/README.md
+++ b/empirical-claims/arithmetic-volumetric-benchmark-v0.1/README.md
@@ -2,6 +2,8 @@
 
 Claim class: `definitional`.
 
+Parent normalization: `prime-log-volume-spectral-normalization@0.1.0`.
+
 This artifact defines a two-axis benchmark surface `Score(u,L)` for finite-window arithmetic signal volume. It is inspired by quantum-volume methodology only in the limited benchmarking sense: both approaches distinguish raw substrate size from usable signal-preserving volume.
 
 It is not a quantum-volume benchmark, not a quantum hardware claim, not a quantum advantage claim, and not an RH/GRH claim.

--- a/empirical-claims/arithmetic-volumetric-benchmark-v0.1/README.md
+++ b/empirical-claims/arithmetic-volumetric-benchmark-v0.1/README.md
@@ -1,0 +1,14 @@
+# Arithmetic Volumetric Benchmark v0.1 Artifact
+
+Claim class: `definitional`.
+
+This artifact defines a two-axis benchmark surface `Score(u,L)` for finite-window arithmetic signal volume. It is inspired by quantum-volume methodology only in the limited benchmarking sense: both approaches distinguish raw substrate size from usable signal-preserving volume.
+
+It is not a quantum-volume benchmark, not a quantum hardware claim, not a quantum advantage claim, and not an RH/GRH claim.
+
+Replay:
+
+```bash
+python3 scripts/check_arithmetic_volumetric_benchmark.py
+python3 -m unittest discover -s tests -p test_arithmetic_volumetric_benchmark.py
+```

--- a/empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json
+++ b/empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json
@@ -1,0 +1,53 @@
+{
+  "benchmark_id": "arithmetic-volumetric-benchmark",
+  "benchmark_version": "0.1.0",
+  "claim_class": "definitional",
+  "parent_normalization": {
+    "normalization_id": "prime-log-volume-spectral-normalization",
+    "normalization_version": "0.1.0"
+  },
+  "axes": {
+    "scale_location": "u",
+    "log_width": "L",
+    "surface": "Score(u,L)",
+    "collapse_to_scalar_allowed": false
+  },
+  "base_policy": {
+    "canonical_base": "e",
+    "display_bases_allowed": true,
+    "score_invariant_under_display_base_change": true
+  },
+  "quantum_volume_relation": {
+    "status": "methodological_analogy_only",
+    "analogy": {
+      "quantum_width_depth": "arithmetic_u_L_surface",
+      "hardware_noise": "density_drift_and_normalization_error",
+      "successful_circuit_volume": "replayable_residual_signal_volume",
+      "volumetric_benchmarking_map": "score_surface"
+    },
+    "equivalence_to_quantum_volume": false,
+    "quantum_hardware_benchmark": false,
+    "quantum_advantage_claim": false
+  },
+  "observable_channels": ["prime_count", "psi"],
+  "scoring_policy": {
+    "fixture_score_formula": "log(1 + corrected_mean_field(u,L)) / (1 + u * L)",
+    "score_must_be_finite": true,
+    "score_must_be_non_negative": true,
+    "score_is_not_theorem_strength": true
+  },
+  "fixtures": [
+    {"u": 20.0, "L": 0.05},
+    {"u": 20.0, "L": 0.2},
+    {"u": 30.0, "L": 0.1},
+    {"u": 40.0, "L": 0.05}
+  ],
+  "claim_boundary": {
+    "allowed": ["benchmark surface definition", "finite-window scoring", "methodological analogy to volumetric benchmarking", "replay harness validation"],
+    "disallowed_without_separate_proof_or_runtime_artifact": ["equivalence to quantum volume", "quantum hardware benchmark", "quantum advantage claim", "proof of RH or GRH", "deterministic primality guarantee", "asymptotic speedup claim"]
+  },
+  "replay_instructions": [
+    "python3 scripts/check_arithmetic_volumetric_benchmark.py",
+    "python3 -m unittest discover -s tests -p test_arithmetic_volumetric_benchmark.py"
+  ]
+}

--- a/empirical-claims/log-volume-normalization-v0.1/README.md
+++ b/empirical-claims/log-volume-normalization-v0.1/README.md
@@ -1,0 +1,12 @@
+# Prime Log-Volume Spectral Normalization v0.1 Artifact
+
+Claim class: `definitional`.
+
+This artifact captures the v0.1 normalization contract for multiplicative prime windows in the canonical coordinate `u = ln(x)`. It locks base gauge, window convention, mean-field subtraction, residual-channel distinction, and claim-boundary guardrails for finite-window empirical work.
+
+Replay:
+
+```bash
+python3 scripts/check_log_volume_normalization.py
+python3 -m unittest discover -s tests -p test_log_volume_normalization.py
+```

--- a/empirical-claims/log-volume-normalization-v0.1/registry.json
+++ b/empirical-claims/log-volume-normalization-v0.1/registry.json
@@ -1,0 +1,57 @@
+{
+  "normalization_id": "prime-log-volume-spectral-normalization",
+  "normalization_version": "0.1.0",
+  "claim_class": "definitional",
+  "coordinate": {
+    "canonical": "u = ln(x)",
+    "inverse": "x = exp(u)",
+    "volume_element": "dx = exp(u) du"
+  },
+  "base_policy": {
+    "canonical_base": "e",
+    "display_bases_allowed": true,
+    "frequency_rescale_rule": "gamma_b = gamma * ln(b)",
+    "score_invariant_under_display_base_change": true
+  },
+  "window": {
+    "type": "multiplicative_log_window",
+    "formula": "W(u,L) = [exp(u), exp(u+L)]",
+    "constraints": ["u > 0", "L > 0"]
+  },
+  "mean_field": {
+    "observable": "prime_count",
+    "formula": "Li(exp(u+L)) - Li(exp(u))",
+    "integral_form": "integral_u_to_u_plus_L exp(v)/v dv",
+    "leading_asymptotic": "exp(u)/u * (exp(L)-1)",
+    "finite_u_correction_required": true
+  },
+  "observable": ["prime_count", "psi"],
+  "residual_definition": {
+    "prime_count": "pi(exp(u+L)) - pi(exp(u)) - MF_count(u,L)",
+    "psi": "psi(exp(u+L)) - psi(exp(u)) - (exp(u+L)-exp(u))"
+  },
+  "phase_basis": {
+    "coordinate": "u",
+    "basis": ["cos(gamma_j u)", "sin(gamma_j u)"],
+    "frequency_source_classes": ["synthetic_grid", "zero_table_declared_context_only", "operator_candidate_declared", "fixture_only"]
+  },
+  "envelope_policy": {
+    "psi_channel": "exp(u/2)",
+    "prime_count_channel_allowed": ["li_rho_leading_channel", "finite_window_empirical_scale", "no_envelope_claim"],
+    "observable_separation_required": true
+  },
+  "finite_window_scope": true,
+  "claim_boundary": {
+    "allowed": ["finite-window ranking", "residual decomposition", "falsifiable heuristic scoring", "normalization lock"],
+    "disallowed_without_separate_proof_artifact": ["unproved global theorem promotion", "deterministic primality guarantee", "asymptotic speedup claim", "zero-location theorem"]
+  },
+  "fixtures": [
+    {"u": 20.0, "L": 0.2},
+    {"u": 30.0, "L": 0.1},
+    {"u": 40.0, "L": 0.05}
+  ],
+  "replay_instructions": [
+    "python3 scripts/check_log_volume_normalization.py",
+    "python3 -m unittest discover -s tests -p test_log_volume_normalization.py"
+  ]
+}

--- a/proof-adapter.json
+++ b/proof-adapter.json
@@ -1,15 +1,106 @@
 {
   "adapter_version": "0.1",
   "repo": "SocioProphet/Heller-Winters-Theorem",
-  "domain": "su2-finite-channel-representation-theory",
+  "domain": "su2-finite-channel-representation-theory and finite-window prime-distribution instrumentation",
   "controller_protocol": "protocol/proof-apparatus-workspace/v0",
-  "claims": [],
+  "claims": [
+    {
+      "claim_id": "HW-LOGVOLUME-001",
+      "state": "draft",
+      "severity": "E7",
+      "substrate": "finite-window prime-distribution normalization",
+      "shell_level": "v0.1 definitional artifact",
+      "projection": "log-volume coordinate, mean-field subtraction, residual-channel separation",
+      "statement": "Prime Log-Volume Spectral Normalization v0.1 defines a replayable normalization contract for finite-window empirical artifacts in the Heller-Winters Programme.",
+      "boundary": [
+        "The claim is definitional and empirical-harness scoped.",
+        "The artifact does not promote an RH, GRH, zero-location, deterministic-primality, or asymptotic-speedup theorem.",
+        "Promotion requires separate theorem-candidate obligations, independent replay, and SocioSphere controller gates."
+      ],
+      "non_claim_refs": [
+        "heller-winters.no-main-theorem-claim",
+        "heller-winters.no-rh-proof-claim",
+        "heller-winters.no-quantum-volume-equivalence"
+      ],
+      "owned_gates": [
+        "log-volume-claim-boundary",
+        "log-volume-non-claim",
+        "log-volume-fixture-check"
+      ],
+      "obstruction_walls": ["certificate_wall"]
+    },
+    {
+      "claim_id": "HW-ARITHVOL-001",
+      "state": "draft",
+      "severity": "E7",
+      "substrate": "finite-window arithmetic volumetric benchmarking",
+      "shell_level": "v0.1 definitional artifact",
+      "projection": "two-axis surface over scale location u and log-width L",
+      "statement": "Arithmetic Volumetric Benchmark v0.1 defines a two-axis benchmark surface for normalized arithmetic signal volume, inspired by quantum-volume methodology but not equivalent to quantum volume.",
+      "boundary": [
+        "The claim is a benchmarking analogy and finite-window harness definition.",
+        "The artifact does not claim quantum hardware execution, quantum advantage, or equivalence to quantum volume.",
+        "Promotion requires a separate compiler/runtime artifact if arithmetic residual tasks are later mapped to quantum circuits."
+      ],
+      "non_claim_refs": [
+        "heller-winters.no-main-theorem-claim",
+        "heller-winters.no-rh-proof-claim",
+        "heller-winters.no-quantum-volume-equivalence"
+      ],
+      "owned_gates": [
+        "arithmetic-volume-claim-boundary",
+        "arithmetic-volume-non-claim",
+        "arithmetic-volume-fixture-check"
+      ],
+      "obstruction_walls": ["certificate_wall"]
+    }
+  ],
   "gates": [
     { "gate_id": "channel-product", "kind": "symbolic_check", "status": "planned" },
     { "gate_id": "jmax-gram", "kind": "symbolic_check", "status": "planned" },
     { "gate_id": "u1-null-model", "kind": "test", "status": "planned" },
     { "gate_id": "wigner-table-reproduction", "kind": "fixture_check", "status": "planned" },
-    { "gate_id": "symbolic-small-jmax", "kind": "symbolic_check", "status": "planned" }
+    { "gate_id": "symbolic-small-jmax", "kind": "symbolic_check", "status": "planned" },
+    {
+      "gate_id": "log-volume-claim-boundary",
+      "kind": "claim_boundary_check",
+      "status": "planned",
+      "expected": "Prime log-volume normalization remains definitional or empirical unless a separate proof artifact promotes it."
+    },
+    {
+      "gate_id": "log-volume-non-claim",
+      "kind": "non_claim_check",
+      "status": "planned",
+      "expected": "Non-claim boxes block RH, GRH, deterministic-primality, zero-location, and asymptotic-speedup overstatement."
+    },
+    {
+      "gate_id": "log-volume-fixture-check",
+      "kind": "test",
+      "status": "planned",
+      "command": "python3 scripts/check_log_volume_normalization.py",
+      "fixture": "empirical-claims/log-volume-normalization-v0.1/registry.json",
+      "expected": "Log-volume normalization registry passes local replay checks."
+    },
+    {
+      "gate_id": "arithmetic-volume-claim-boundary",
+      "kind": "claim_boundary_check",
+      "status": "planned",
+      "expected": "Arithmetic volumetric benchmark remains a benchmarking analogy unless separate runtime/proof artifacts promote it."
+    },
+    {
+      "gate_id": "arithmetic-volume-non-claim",
+      "kind": "non_claim_check",
+      "status": "planned",
+      "expected": "Non-claim boxes block quantum-volume equivalence, quantum hardware benchmark, and quantum advantage claims."
+    },
+    {
+      "gate_id": "arithmetic-volume-fixture-check",
+      "kind": "test",
+      "status": "planned",
+      "command": "python3 scripts/check_arithmetic_volumetric_benchmark.py",
+      "fixture": "empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json",
+      "expected": "Arithmetic volumetric benchmark registry passes local replay checks."
+    }
   ],
   "non_claims": [
     {
@@ -23,6 +114,21 @@
     {
       "non_claim_id": "heller-winters.no-finite-cutoff-promotion",
       "statement": "This adapter does not promote finite-channel or finite-cutoff evidence to a continuum theorem."
+    },
+    {
+      "non_claim_id": "heller-winters.no-main-theorem-claim",
+      "statement": "This adapter does not claim a completed Heller-Winters theorem or final prime-distribution theorem.",
+      "applies_to": ["HW-LOGVOLUME-001", "HW-ARITHVOL-001"]
+    },
+    {
+      "non_claim_id": "heller-winters.no-rh-proof-claim",
+      "statement": "This adapter does not claim a proof of RH, GRH, zero-location, deterministic primality, or asymptotic speedup.",
+      "applies_to": ["HW-LOGVOLUME-001", "HW-ARITHVOL-001"]
+    },
+    {
+      "non_claim_id": "heller-winters.no-quantum-volume-equivalence",
+      "statement": "Arithmetic volumetric benchmarking is a methodological analogy to quantum-volume-style benchmarking, not an equivalence to quantum volume and not a quantum hardware benchmark.",
+      "applies_to": ["HW-ARITHVOL-001"]
     }
   ]
 }

--- a/scripts/check_arithmetic_volumetric_benchmark.py
+++ b/scripts/check_arithmetic_volumetric_benchmark.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+BENCHMARK_PATH = Path("empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json")
+PARENT_PATH = Path("empirical-claims/log-volume-normalization-v0.1/registry.json")
+REQUIRED = {
+    "benchmark_id", "benchmark_version", "claim_class", "parent_normalization",
+    "axes", "base_policy", "quantum_volume_relation", "observable_channels",
+    "scoring_policy", "fixtures", "claim_boundary", "replay_instructions"
+}
+BANNED = {
+    "equivalence to quantum volume", "quantum hardware benchmark",
+    "quantum advantage claim", "proof of RH or GRH",
+    "deterministic primality guarantee", "asymptotic speedup claim"
+}
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_registry(path: Path = BENCHMARK_PATH) -> dict:
+    return load_json(path)
+
+
+def assert_required_fields(registry: dict) -> None:
+    missing = REQUIRED.difference(registry)
+    if missing:
+        raise AssertionError(f"missing fields: {sorted(missing)}")
+
+
+def check_parent_normalization(registry: dict) -> dict:
+    parent = registry["parent_normalization"]
+    actual = load_json(PARENT_PATH)
+    if parent["normalization_id"] != actual["normalization_id"]:
+        raise AssertionError("parent normalization id mismatch")
+    if parent["normalization_version"] != actual["normalization_version"]:
+        raise AssertionError("parent normalization version mismatch")
+    return {"pass": True}
+
+
+def check_two_axis_surface(registry: dict) -> dict:
+    axes = registry["axes"]
+    if axes.get("scale_location") != "u" or axes.get("log_width") != "L":
+        raise AssertionError("benchmark must preserve u and L axes")
+    if axes.get("collapse_to_scalar_allowed") is not False:
+        raise AssertionError("v0.1 must not collapse to scalar without a declared rule")
+    return {"pass": True, "surface": axes.get("surface")}
+
+
+def corrected_mean_field(u: float, L: float) -> float:
+    leading = math.exp(u) / u * (math.exp(L) - 1.0)
+    correction = math.exp(u) / (u * u) * (((L - 1.0) * math.exp(L)) + 1.0)
+    return leading - correction
+
+
+def fixture_score(u: float, L: float) -> float:
+    return math.log1p(corrected_mean_field(u, L)) / (1.0 + u * L)
+
+
+def check_fixture_scores(registry: dict) -> dict:
+    scores = []
+    for fixture in registry["fixtures"]:
+        u, L = float(fixture["u"]), float(fixture["L"])
+        score = fixture_score(u, L)
+        if not math.isfinite(score) or score < 0.0:
+            raise AssertionError(f"invalid score: u={u}, L={L}, score={score}")
+        scores.append({"u": u, "L": L, "score": score})
+    return {"pass": True, "scores": scores}
+
+
+def check_quantum_volume_boundary(registry: dict) -> dict:
+    relation = registry["quantum_volume_relation"]
+    if relation.get("status") != "methodological_analogy_only":
+        raise AssertionError("relation must be methodology-only analogy")
+    for key in ("equivalence_to_quantum_volume", "quantum_hardware_benchmark", "quantum_advantage_claim"):
+        if relation.get(key) is not False:
+            raise AssertionError(f"must deny {key}")
+    if "quantum_width_depth" not in relation.get("analogy", {}):
+        raise AssertionError("analogy map incomplete")
+    return {"pass": True}
+
+
+def check_claim_boundary(registry: dict) -> dict:
+    disallowed = set(registry["claim_boundary"]["disallowed_without_separate_proof_or_runtime_artifact"])
+    missing = BANNED.difference(disallowed)
+    if missing:
+        raise AssertionError(f"missing banned claims: {sorted(missing)}")
+    return {"pass": True}
+
+
+def run_checks() -> dict:
+    registry = load_registry()
+    assert_required_fields(registry)
+    return {
+        "required_fields": {"pass": True},
+        "parent_normalization": check_parent_normalization(registry),
+        "two_axis_surface": check_two_axis_surface(registry),
+        "fixture_scores": check_fixture_scores(registry),
+        "quantum_volume_boundary": check_quantum_volume_boundary(registry),
+        "claim_boundary": check_claim_boundary(registry),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_checks(), indent=2, sort_keys=True))

--- a/scripts/check_log_volume_normalization.py
+++ b/scripts/check_log_volume_normalization.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+REGISTRY_PATH = Path("empirical-claims/log-volume-normalization-v0.1/registry.json")
+REQUIRED = {
+    "normalization_id", "normalization_version", "claim_class", "coordinate",
+    "base_policy", "window", "mean_field", "observable", "residual_definition",
+    "phase_basis", "envelope_policy", "finite_window_scope", "claim_boundary",
+    "fixtures", "replay_instructions"
+}
+BANNED = {
+    "unproved global theorem promotion", "deterministic primality guarantee",
+    "asymptotic speedup claim", "zero-location theorem"
+}
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def assert_required_fields(registry: dict) -> None:
+    missing = REQUIRED.difference(registry)
+    if missing:
+        raise AssertionError(f"missing fields: {sorted(missing)}")
+
+
+def check_base_gauge_invariance() -> dict:
+    max_delta = 0.0
+    for x in (3.0, 101.0, 10007.0, math.exp(30.0)):
+        for gamma in (0.5, 1.0, 14.134725141):
+            natural = gamma * math.log(x)
+            for base in (2.0, math.e, 10.0, 16.0):
+                displayed = (gamma * math.log(base)) * (math.log(x) / math.log(base))
+                max_delta = max(max_delta, abs(natural - displayed))
+    if max_delta >= 1e-10:
+        raise AssertionError(f"base gauge delta too large: {max_delta}")
+    return {"pass": True, "max_delta": max_delta}
+
+
+def simpson_exp_over_v(u: float, L: float, panels: int = 4096) -> float:
+    if panels % 2:
+        panels += 1
+    h = L / panels
+    total = math.exp(u) / u + math.exp(u + L) / (u + L)
+    for k in range(1, panels):
+        v = u + k * h
+        total += (4.0 if k % 2 else 2.0) * math.exp(v) / v
+    return total * h / 3.0
+
+
+def leading(u: float, L: float) -> float:
+    return math.exp(u) / u * (math.exp(L) - 1.0)
+
+
+def corrected(u: float, L: float) -> float:
+    return leading(u, L) - math.exp(u) / (u * u) * (((L - 1.0) * math.exp(L)) + 1.0)
+
+
+def check_mean_field_correction(fixtures: list[dict]) -> dict:
+    cases = []
+    for fixture in fixtures:
+        u, L = float(fixture["u"]), float(fixture["L"])
+        numeric = simpson_exp_over_v(u, L)
+        e0 = abs(leading(u, L) - numeric)
+        e1 = abs(corrected(u, L) - numeric)
+        if e1 >= e0:
+            raise AssertionError(f"correction failed: u={u}, L={L}, leading={e0}, corrected={e1}")
+        cases.append({"u": u, "L": L, "leading_error": e0, "corrected_error": e1})
+    return {"pass": True, "cases": cases}
+
+
+def check_observable_separation(registry: dict) -> dict:
+    policy = registry["envelope_policy"]
+    if policy.get("psi_channel") != "exp(u/2)":
+        raise AssertionError("psi channel envelope must be exp(u/2)")
+    allowed = policy.get("prime_count_channel_allowed", [])
+    if "no_envelope_claim" not in allowed:
+        raise AssertionError("prime-count channel must allow no_envelope_claim")
+    if "exp(u/2)" in allowed:
+        raise AssertionError("prime-count channel must not inherit psi envelope directly")
+    return {"pass": True}
+
+
+def check_claim_boundary(registry: dict) -> dict:
+    disallowed = set(registry["claim_boundary"]["disallowed_without_separate_proof_artifact"])
+    missing = BANNED.difference(disallowed)
+    if missing:
+        raise AssertionError(f"missing banned claims: {sorted(missing)}")
+    return {"pass": True}
+
+
+def run_checks() -> dict:
+    registry = load_registry()
+    assert_required_fields(registry)
+    return {
+        "required_fields": {"pass": True},
+        "base_gauge_invariance": check_base_gauge_invariance(),
+        "mean_field_correction": check_mean_field_correction(registry["fixtures"]),
+        "observable_separation": check_observable_separation(registry),
+        "claim_boundary": check_claim_boundary(registry),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_checks(), indent=2, sort_keys=True))

--- a/tests/test_arithmetic_volumetric_benchmark.py
+++ b/tests/test_arithmetic_volumetric_benchmark.py
@@ -1,0 +1,46 @@
+import importlib.util
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "check_arithmetic_volumetric_benchmark.py"
+spec = importlib.util.spec_from_file_location("check_arithmetic_volumetric_benchmark", MODULE_PATH)
+check = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(check)
+
+
+class ArithmeticVolumetricBenchmarkTests(unittest.TestCase):
+    def test_required_fields(self):
+        registry = check.load_registry(ROOT / "empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json")
+        check.assert_required_fields(registry)
+        self.assertEqual(registry["claim_class"], "definitional")
+
+    def test_parent_normalization(self):
+        registry = check.load_registry(ROOT / "empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json")
+        self.assertTrue(check.check_parent_normalization(registry)["pass"])
+
+    def test_two_axis_surface(self):
+        registry = check.load_registry(ROOT / "empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json")
+        result = check.check_two_axis_surface(registry)
+        self.assertTrue(result["pass"])
+        self.assertEqual(result["surface"], "Score(u,L)")
+
+    def test_fixture_scores(self):
+        registry = check.load_registry(ROOT / "empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json")
+        result = check.check_fixture_scores(registry)
+        self.assertTrue(result["pass"])
+        for entry in result["scores"]:
+            self.assertGreaterEqual(entry["score"], 0.0)
+
+    def test_quantum_volume_boundary(self):
+        registry = check.load_registry(ROOT / "empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json")
+        self.assertTrue(check.check_quantum_volume_boundary(registry)["pass"])
+
+    def test_claim_boundary(self):
+        registry = check.load_registry(ROOT / "empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json")
+        self.assertTrue(check.check_claim_boundary(registry)["pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_log_volume_normalization.py
+++ b/tests/test_log_volume_normalization.py
@@ -1,0 +1,39 @@
+import importlib.util
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "check_log_volume_normalization.py"
+spec = importlib.util.spec_from_file_location("check_log_volume_normalization", MODULE_PATH)
+check = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(check)
+
+
+class LogVolumeNormalizationTests(unittest.TestCase):
+    def test_required_fields(self):
+        registry = check.load_registry(ROOT / "empirical-claims/log-volume-normalization-v0.1/registry.json")
+        check.assert_required_fields(registry)
+        self.assertEqual(registry["claim_class"], "definitional")
+
+    def test_base_gauge_invariance(self):
+        self.assertTrue(check.check_base_gauge_invariance()["pass"])
+
+    def test_mean_field_correction(self):
+        registry = check.load_registry(ROOT / "empirical-claims/log-volume-normalization-v0.1/registry.json")
+        result = check.check_mean_field_correction(registry["fixtures"])
+        self.assertTrue(result["pass"])
+        for case in result["cases"]:
+            self.assertLess(case["corrected_error"], case["leading_error"])
+
+    def test_observable_separation(self):
+        registry = check.load_registry(ROOT / "empirical-claims/log-volume-normalization-v0.1/registry.json")
+        self.assertTrue(check.check_observable_separation(registry)["pass"])
+
+    def test_claim_boundary(self):
+        registry = check.load_registry(ROOT / "empirical-claims/log-volume-normalization-v0.1/registry.json")
+        self.assertTrue(check.check_claim_boundary(registry)["pass"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds two definitional / empirical-harness artifacts for the Heller-Winters Programme:

1. Prime Log-Volume Spectral Normalization v0.1
2. Arithmetic Volumetric Benchmark v0.1

The first locks the canonical log-volume coordinate, multiplicative window convention, mean-field subtraction, residual channel separation, and claim-boundary discipline.

The second extends that normalization into a two-axis `Score(u,L)` benchmark surface inspired by quantum-volume-style methodology while explicitly denying quantum-volume equivalence, quantum-hardware benchmark status, and quantum-advantage claims.

## Proof-apparatus integration

Adds `proof-adapter.json` so SocioSphere proof-apparatus materialization can treat this repo as an explicit proof-domain participant with draft definitional claims and non-claim boxes.

## Validation commands

```bash
python3 scripts/check_log_volume_normalization.py
python3 -m unittest discover -s tests -p test_log_volume_normalization.py
python3 scripts/check_arithmetic_volumetric_benchmark.py
python3 -m unittest discover -s tests -p test_arithmetic_volumetric_benchmark.py
```

## Claim boundary

This is not a theorem-promotion PR. It does not claim deterministic primality, asymptotic speedup, RH/GRH proof, zero-location theorem, quantum hardware benchmarking, or quantum advantage.
