### PR TITLE
Add arithmetic volumetric surface runner v0.2

### DIFF
--- a/.github/workflows/arithmetic-volumetric-surface.yml
+++ b/.github/workflows/arithmetic-volumetric-surface.yml
@@ -1,0 +1,18 @@
+name: arithmetic-volumetric-surface
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run surface fixture
+        run: python3 scripts/run_arithmetic_volumetric_surface.py --artifact-dir /tmp/arithvol-surface
+      - name: Run surface tests
+        run: python3 -m unittest discover -s tests -p test_arithmetic_volumetric_surface.py

--- a/empirical-claims/arithmetic-volumetric-benchmark-v0.2/README.md
+++ b/empirical-claims/arithmetic-volumetric-benchmark-v0.2/README.md
@@ -1,0 +1,22 @@
+# Arithmetic Volumetric Surface Runner v0.2
+
+Claim class: `empirical`.
+
+This artifact upgrades Arithmetic Volumetric Benchmark v0.1 from a definitional benchmark surface into an executable finite-window surface runner.
+
+It generates a deterministic `Score(u,L)` grid over declared log-volume windows and emits:
+
+```text
+surface.json
+summary.md
+pfk_receipt.json
+```
+
+The score is finite-window instrumentation only. It is not theorem strength, not quantum volume, not a quantum hardware benchmark, not a quantum advantage claim, and not an RH/GRH claim.
+
+Replay:
+
+```bash
+python3 scripts/run_arithmetic_volumetric_surface.py --artifact-dir empirical-claims/arithmetic-volumetric-benchmark-v0.2/results/fixture
+python3 -m unittest discover -s tests -p test_arithmetic_volumetric_surface.py
+```

--- a/empirical-claims/arithmetic-volumetric-benchmark-v0.2/registry.json
+++ b/empirical-claims/arithmetic-volumetric-benchmark-v0.2/registry.json
@@ -1,0 +1,43 @@
+{
+  "artifact_id": "arithmetic-volumetric-surface-runner",
+  "artifact_version": "0.2.0",
+  "claim_class": "empirical",
+  "parent_benchmark": {
+    "benchmark_id": "arithmetic-volumetric-benchmark",
+    "benchmark_version": "0.1.0"
+  },
+  "parent_normalization": {
+    "normalization_id": "prime-log-volume-spectral-normalization",
+    "normalization_version": "0.1.0"
+  },
+  "surface_axes": ["u", "L"],
+  "default_grid": {
+    "u_values": [20.0, 30.0, 40.0],
+    "L_values": [0.05, 0.1, 0.2]
+  },
+  "score_policy": {
+    "formula": "log1p(corrected_mean_field(u,L)) / (1 + u * L)",
+    "score_is_finite_window_only": true,
+    "score_is_not_theorem_strength": true
+  },
+  "outputs": ["surface.json", "summary.md", "pfk_receipt.json"],
+  "claim_boundary": {
+    "allowed": [
+      "finite-window benchmark surface generation",
+      "deterministic replay receipt",
+      "methodological analogy to volumetric benchmarking"
+    ],
+    "disallowed": [
+      "equivalence to quantum volume",
+      "quantum hardware benchmark",
+      "quantum advantage claim",
+      "proof of RH or GRH",
+      "deterministic primality guarantee",
+      "asymptotic speedup claim"
+    ]
+  },
+  "replay_instructions": [
+    "python3 scripts/run_arithmetic_volumetric_surface.py --artifact-dir empirical-claims/arithmetic-volumetric-benchmark-v0.2/results/fixture",
+    "python3 -m unittest discover -s tests -p test_arithmetic_volumetric_surface.py"
+  ]
+}

--- a/proof-adapter.json
+++ b/proof-adapter.json
@@ -53,6 +53,31 @@
         "arithmetic-volume-fixture-check"
       ],
       "obstruction_walls": ["certificate_wall"]
+    },
+    {
+      "claim_id": "HW-ARITHVOL-SURFACE-002",
+      "state": "draft",
+      "severity": "E7",
+      "substrate": "finite-window arithmetic volumetric surface replay",
+      "shell_level": "v0.2 empirical runner artifact",
+      "projection": "deterministic Score(u,L) grid with PFK-style receipt",
+      "statement": "Arithmetic Volumetric Surface Runner v0.2 generates a deterministic finite-window Score(u,L) surface and replay receipt for declared log-volume grids.",
+      "boundary": [
+        "The claim is empirical and finite-window scoped.",
+        "The surface score is not theorem strength and does not promote RH, GRH, deterministic primality, or asymptotic speedup.",
+        "The quantum-volume relation remains methodological analogy only and is not a quantum hardware benchmark or quantum advantage claim."
+      ],
+      "non_claim_refs": [
+        "heller-winters.no-main-theorem-claim",
+        "heller-winters.no-rh-proof-claim",
+        "heller-winters.no-quantum-volume-equivalence"
+      ],
+      "owned_gates": [
+        "arithmetic-volume-surface-claim-boundary",
+        "arithmetic-volume-surface-non-claim",
+        "arithmetic-volume-surface-fixture-check"
+      ],
+      "obstruction_walls": ["certificate_wall"]
     }
   ],
   "gates": [
@@ -100,6 +125,26 @@
       "command": "python3 scripts/check_arithmetic_volumetric_benchmark.py",
       "fixture": "empirical-claims/arithmetic-volumetric-benchmark-v0.1/registry.json",
       "expected": "Arithmetic volumetric benchmark registry passes local replay checks."
+    },
+    {
+      "gate_id": "arithmetic-volume-surface-claim-boundary",
+      "kind": "claim_boundary_check",
+      "status": "planned",
+      "expected": "Arithmetic volumetric surface runner remains finite-window empirical instrumentation."
+    },
+    {
+      "gate_id": "arithmetic-volume-surface-non-claim",
+      "kind": "non_claim_check",
+      "status": "planned",
+      "expected": "Non-claim boxes block quantum-volume equivalence, quantum advantage, theorem-strength, and RH/GRH overstatement."
+    },
+    {
+      "gate_id": "arithmetic-volume-surface-fixture-check",
+      "kind": "test",
+      "status": "planned",
+      "command": "python3 scripts/run_arithmetic_volumetric_surface.py --artifact-dir /tmp/arithvol-surface && python3 -m unittest discover -s tests -p test_arithmetic_volumetric_surface.py",
+      "fixture": "empirical-claims/arithmetic-volumetric-benchmark-v0.2/registry.json",
+      "expected": "Arithmetic volumetric surface runner emits deterministic surface, summary, and receipt outputs."
     }
   ],
   "non_claims": [
@@ -118,17 +163,17 @@
     {
       "non_claim_id": "heller-winters.no-main-theorem-claim",
       "statement": "This adapter does not claim a completed Heller-Winters theorem or final prime-distribution theorem.",
-      "applies_to": ["HW-LOGVOLUME-001", "HW-ARITHVOL-001"]
+      "applies_to": ["HW-LOGVOLUME-001", "HW-ARITHVOL-001", "HW-ARITHVOL-SURFACE-002"]
     },
     {
       "non_claim_id": "heller-winters.no-rh-proof-claim",
       "statement": "This adapter does not claim a proof of RH, GRH, zero-location, deterministic primality, or asymptotic speedup.",
-      "applies_to": ["HW-LOGVOLUME-001", "HW-ARITHVOL-001"]
+      "applies_to": ["HW-LOGVOLUME-001", "HW-ARITHVOL-001", "HW-ARITHVOL-SURFACE-002"]
     },
     {
       "non_claim_id": "heller-winters.no-quantum-volume-equivalence",
       "statement": "Arithmetic volumetric benchmarking is a methodological analogy to quantum-volume-style benchmarking, not an equivalence to quantum volume and not a quantum hardware benchmark.",
-      "applies_to": ["HW-ARITHVOL-001"]
+      "applies_to": ["HW-ARITHVOL-001", "HW-ARITHVOL-SURFACE-002"]
     }
   ]
 }

--- a/scripts/run_arithmetic_volumetric_surface.py
+++ b/scripts/run_arithmetic_volumetric_surface.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Arithmetic Volumetric Surface Runner v0.2.
+
+Finite-window empirical runner for Score(u,L). This is not a theorem,
+not quantum-volume equivalence, and not a quantum-advantage claim.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import platform
+import sys
+import time
+from pathlib import Path
+from typing import Sequence
+
+REGISTRY_PATH = Path("empirical-claims/arithmetic-volumetric-benchmark-v0.2/registry.json")
+DEFAULT_ARTIFACT_DIR = Path("empirical-claims/arithmetic-volumetric-benchmark-v0.2/results/fixture")
+
+
+def parse_float_csv(text: str) -> list[float]:
+    values = [float(part.strip()) for part in text.split(",") if part.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one numeric value")
+    if any(value <= 0.0 for value in values):
+        raise argparse.ArgumentTypeError("all values must be positive")
+    return values
+
+
+def canonical_json_sha256(payload: dict) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def corrected_mean_field(u: float, L: float) -> float:
+    if u <= 0.0 or L <= 0.0:
+        raise ValueError("u and L must be positive")
+    leading = math.exp(u) / u * (math.exp(L) - 1.0)
+    correction = math.exp(u) / (u * u) * (((L - 1.0) * math.exp(L)) + 1.0)
+    return leading - correction
+
+
+def benchmark_score(u: float, L: float) -> float:
+    mf = corrected_mean_field(u, L)
+    if mf < 0.0:
+        raise ValueError(f"corrected mean field must be non-negative, got {mf}")
+    return math.log1p(mf) / (1.0 + u * L)
+
+
+def build_surface(u_values: Sequence[float], L_values: Sequence[float]) -> dict:
+    cells = []
+    for u in u_values:
+        for L in L_values:
+            mf = corrected_mean_field(u, L)
+            cells.append({
+                "u": u,
+                "L": L,
+                "x_start": math.exp(u),
+                "x_end": math.exp(u + L),
+                "corrected_mean_field": mf,
+                "score": benchmark_score(u, L),
+            })
+    scores = [cell["score"] for cell in cells]
+    return {
+        "axes": {"u_values": list(u_values), "L_values": list(L_values)},
+        "cells": cells,
+        "summary": {
+            "cell_count": len(cells),
+            "score_min": min(scores),
+            "score_max": max(scores),
+            "score_mean": sum(scores) / len(scores),
+        },
+    }
+
+
+def write_outputs(result: dict, receipt: dict, artifact_dir: Path) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / "surface.json").write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (artifact_dir / "pfk_receipt.json").write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary = result["surface"]["summary"]
+    lines = [
+        "# Arithmetic Volumetric Surface Run Summary",
+        "",
+        f"Artifact: `{result['artifact_id']}@{result['artifact_version']}`",
+        f"Claim class: `{result['claim_class']}`",
+        f"Deterministic hash: `{receipt['deterministic_result_sha256']}`",
+        "",
+        "## Surface summary",
+        "",
+        f"- cells: {summary['cell_count']}",
+        f"- score min: {summary['score_min']}",
+        f"- score max: {summary['score_max']}",
+        f"- score mean: {summary['score_mean']}",
+        "",
+        "## Non-claim boundary",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in receipt["non_claim_boundary"])
+    (artifact_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_surface(u_values: Sequence[float], L_values: Sequence[float], artifact_dir: Path) -> tuple[dict, dict]:
+    start = time.time()
+    registry = load_registry()
+    deterministic_payload = {
+        "artifact_id": registry["artifact_id"],
+        "artifact_version": registry["artifact_version"],
+        "claim_class": registry["claim_class"],
+        "parent_benchmark": registry["parent_benchmark"],
+        "parent_normalization": registry["parent_normalization"],
+        "score_policy": registry["score_policy"],
+        "claim_boundary": registry["claim_boundary"],
+        "surface": build_surface(u_values, L_values),
+    }
+    digest = canonical_json_sha256(deterministic_payload)
+    result = {
+        **deterministic_payload,
+        "deterministic_result_sha256": digest,
+        "runtime": {"seconds": time.time() - start, "python": sys.version, "platform": platform.platform()},
+    }
+    receipt = {
+        "artifact_id": registry["artifact_id"],
+        "artifact_version": registry["artifact_version"],
+        "claim_class": registry["claim_class"],
+        "deterministic_result_sha256": digest,
+        "result_file": "surface.json",
+        "summary_file": "summary.md",
+        "non_claim_boundary": registry["claim_boundary"]["disallowed"],
+    }
+    write_outputs(result, receipt, artifact_dir)
+    return result, receipt
+
+
+def main() -> None:
+    registry = load_registry()
+    defaults = registry["default_grid"]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--u-values", type=parse_float_csv, default=defaults["u_values"])
+    parser.add_argument("--L-values", type=parse_float_csv, default=defaults["L_values"])
+    parser.add_argument("--artifact-dir", type=Path, default=DEFAULT_ARTIFACT_DIR)
+    args = parser.parse_args()
+    _, receipt = run_surface(args.u_values, args.L_values, args.artifact_dir)
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_arithmetic_volumetric_surface.py
+++ b/tests/test_arithmetic_volumetric_surface.py
@@ -1,0 +1,45 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "run_arithmetic_volumetric_surface.py"
+
+spec = importlib.util.spec_from_file_location("run_arithmetic_volumetric_surface", MODULE_PATH)
+runner = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(runner)
+
+
+class ArithmeticVolumetricSurfaceTests(unittest.TestCase):
+    def test_corrected_mean_field_positive(self):
+        self.assertGreater(runner.corrected_mean_field(20.0, 0.1), 0.0)
+
+    def test_score_finite_non_negative(self):
+        score = runner.benchmark_score(30.0, 0.1)
+        self.assertGreaterEqual(score, 0.0)
+
+    def test_surface_cell_count(self):
+        surface = runner.build_surface([20.0, 30.0], [0.05, 0.1])
+        self.assertEqual(surface["summary"]["cell_count"], 4)
+        self.assertEqual(len(surface["cells"]), 4)
+
+    def test_surface_outputs_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result, receipt = runner.run_surface([20.0], [0.05, 0.1], pathlib.Path(tmp))
+            self.assertEqual(result["surface"]["summary"]["cell_count"], 2)
+            self.assertTrue((pathlib.Path(tmp) / "surface.json").exists())
+            self.assertTrue((pathlib.Path(tmp) / "summary.md").exists())
+            self.assertTrue((pathlib.Path(tmp) / "pfk_receipt.json").exists())
+            self.assertEqual(receipt["deterministic_result_sha256"], result["deterministic_result_sha256"])
+
+    def test_claim_boundary_denies_quantum_equivalence(self):
+        registry = runner.load_registry()
+        disallowed = set(registry["claim_boundary"]["disallowed"])
+        self.assertIn("equivalence to quantum volume", disallowed)
+        self.assertIn("quantum advantage claim", disallowed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds Arithmetic Volumetric Surface Runner v0.2 as an executable finite-window empirical artifact on top of the merged v0.1 log-volume / arithmetic-volume benchmark substrate.

This PR adds:

- `empirical-claims/arithmetic-volumetric-benchmark-v0.2/README.md`
- `empirical-claims/arithmetic-volumetric-benchmark-v0.2/registry.json`
- `scripts/run_arithmetic_volumetric_surface.py`
- `tests/test_arithmetic_volumetric_surface.py`
- `.github/workflows/arithmetic-volumetric-surface.yml`
- proof-adapter registration for `HW-ARITHVOL-SURFACE-002`

## What it does

The runner generates a deterministic finite-window `Score(u,L)` grid over declared log-volume windows and emits:

```text
surface.json
summary.md
pfk_receipt.json
```

## Validation

Local preflight passed before connector commit:

```bash
python3 scripts/run_arithmetic_volumetric_surface.py --artifact-dir /tmp/arithvol-surface
python3 -m unittest discover -s tests -p test_arithmetic_volumetric_surface.py
```

Observed:

```text
Ran 5 tests in 0.028s
OK
```

## Claim boundary

Finite-window empirical runner only. No theorem promotion, no RH/GRH proof claim, no deterministic-primality claim, no asymptotic-speedup claim, no quantum-volume equivalence, and no quantum-advantage claim.
