### PR TITLE
Correct A2 minimality sketch invariant data

### DIFF
--- a/docs/a2-corrected-minimality-sketch.md
+++ b/docs/a2-corrected-minimality-sketch.md
@@ -1,0 +1,145 @@
+# Corrected A₂ minimality sketch
+
+**Status:** controlled correction note.  
+**Scope:** replaces the withdrawn cubic-invariant A₂ sketch.  
+**Boundary:** sketch-level only; not a theorem, not a proof of A₂ gate-minimality, and not a continuum Yang--Mills claim.
+
+## 1. Correction
+
+The earlier A₂ sketch used an incorrect invariant claim:
+
+> SU(3) preserves a unique cubic invariant on the fundamental representation `V_A = C^3`.
+
+That statement is false. It conflates the adjoint representation with the fundamental representation.
+
+Correct invariant facts for the fundamental representation `V = C^3` are:
+
+| Form on `V = C^3` | SU(3)-invariant? | Note |
+|---|---:|---|
+| Hermitian form `H(v,w) = v†w` | yes | unitary structure |
+| Symmetric bilinear form `v^T w` | no | would imply an orthogonal branch |
+| Alternating volume `epsilon(v,w,u) = det(v,w,u)` | yes | determinant-one structure |
+| Symmetric trilinear in `Sym^3 V*` | no | no trivial summand in `Sym^3 V*` |
+| `d^{abc}` cubic tensor | yes on adjoint | lives on the `8`-dimensional adjoint, not `C^3` |
+
+Therefore the cubic-invariant version of the A₂ sketch is withdrawn.
+
+## 2. Corpus convention: lattice tower, not free path choice
+
+The program uses `A_1, A_2, D_4, E_8` in the lattice / Lie-algebra tower sense.
+
+The intended tower is:
+
+```text
+A_1  <-> rank-1 root system       <-> sl(2) / SU(2) <-> mu_2
+A_2  <-> Eisenstein / A2 lattice  <-> sl(3) / SU(3) <-> mu_3
+D_4  <-> Hurwitz quaternion lane  <-> Spin(8) triality
+E_8  <-> octonion / Cayley lane   <-> E8 structure
+```
+
+Accordingly, the corrected A₂ default is not a choice between unrelated paths. It follows the `A_n <-> sl(n+1)` rule:
+
+```text
+G_{A2} = SU(3)
+V_A    = C^3
+zeta   = omega I_3, where omega = exp(2 pi i / 3)
+```
+
+## 3. Dimension correction
+
+`SU(3)` has no faithful two-dimensional complex representation. The smallest non-trivial irreducible representations are:
+
+```text
+3      fundamental
+bar 3  antifundamental
+8      adjoint
+```
+
+Therefore an A₁ setup with `dim V_A = 2` cannot extend to A₂ with the same `dim V_A` and faithful `SU(3)` action. The minimal faithful A₂ choice is `V_A = C^3` with the fundamental representation.
+
+## 4. Corrected polarization compatibility
+
+For A₂ the polarization compatibility should be stated as two clauses.
+
+### (v_A2) Preserved Hermitian and volume structures
+
+The active representation preserves:
+
+```text
+H_A : V_A x conjugate(V_A) -> C
+epsilon_A in wedge^3 V_A^*
+```
+
+These are the Hermitian form and alternating volume form on `C^3`.
+
+### (v_A2') No additional symmetric bilinear structure
+
+The active representation does **not** preserve any symmetric bilinear form on `V_A`.
+
+This exclusion is necessary because `SO(3) < SU(3)` can preserve both a Hermitian form and an alternating volume form through the complexified standard representation. It is distinguished by preserving an additional symmetric bilinear form. The A₂ branch must exclude that orthogonal structure explicitly.
+
+## 5. Corrected A₂ minimality conjecture
+
+> **Corrected sketch conjecture `T_A2`.** Under the A₂ lattice-tower convention, with `(i)--(iv)` restated for `mu_3` monodromy and a central element of order `3`, and with `(v_A2)` plus `(v_A2')`, the admissible A₂ class has a unique minimal representative up to isomorphism:
+>
+> ```text
+> (SU(3), rho_def),    V_A = C^3,    zeta = omega I_3.
+> ```
+>
+> This is a sketch target, not a theorem.
+
+## 6. Open Spin-target issue
+
+The A₂ spatial / spin-frame target is not fixed by this correction note.
+
+Open candidates include:
+
+```text
+SU(3) itself
+SU(4) ~= Spin(6)
+A2 -> D4 lattice-tower embedding
+```
+
+This correction note does not select among those targets. It only corrects the A₂ representation-theoretic invariant data and prevents the false cubic-on-fundamental claim from propagating.
+
+## 7. Product structure with A₁
+
+The `mu_6 = Z[omega]^x` structure suggests that the combined A₁/A₂ gate should be treated as a product of the `mu_2` and `mu_3` components:
+
+```text
+A1 component: SU(2), center element -I
+A2 component: SU(3), center element omega I_3
+combined order: lcm(2, 3) = 6
+candidate product: SU(2) x SU(3)
+representation surface: C^2 tensor C^3 = C^6
+```
+
+This is a future product-gate target. It is not established by the corrected A₂ sketch.
+
+## 8. Non-claims
+
+This note does not claim:
+
+- that A₂ minimality is proved;
+- that the A₂ Spin-target has been selected;
+- that a cubic invariant exists on the SU(3) fundamental representation;
+- that adjoint `d^{abc}` data may be used as a fundamental-representation invariant;
+- that the A₁ proof transfers automatically to A₂;
+- that the `SU(2) x SU(3)` product gate is proved;
+- that any continuum Yang--Mills mass-gap consequence follows from this sketch.
+
+## 9. Implementation consequence
+
+Any downstream A₂ note or issue must use:
+
+```text
+Hermitian + alternating volume + no symmetric bilinear
+```
+
+not:
+
+```text
+Hermitian + cubic d-symbol on C^3
+```
+
+The adjoint `d`-symbol remains valid adjoint-representation data, but it is not the A₂ fundamental-representation polarization.

--- a/fixtures/valid/cl-003-a2-correction.yaml
+++ b/fixtures/valid/cl-003-a2-correction.yaml
@@ -8,7 +8,7 @@ artifact_refs:
     version: "v0.1"
 run_receipt_ids: []
 demotion_reason: null
-manuscript_editing_rule: false
+manuscript_editing_rule: true
 promoted_from: null
 created: "2026-05-14T00:00:00Z"
 last_modified: "2026-05-14T00:00:00Z"

--- a/fixtures/valid/cl-003-a2-correction.yaml
+++ b/fixtures/valid/cl-003-a2-correction.yaml
@@ -1,0 +1,14 @@
+claim_id: "CL-003"
+claim_class: "C1"
+statement: "The A2 minimality sketch must use the SU(3) fundamental representation with Hermitian plus alternating volume structure and an explicit no-symmetric-bilinear exclusion; the prior cubic-invariant-on-C3 framing is withdrawn."
+operator_refs: []
+artifact_refs:
+  - artifact_id: "A2-CORRECTED-MINIMALITY-SKETCH-001"
+    artifact_type: "ProofArtifact"
+    version: "v0.1"
+run_receipt_ids: []
+demotion_reason: null
+manuscript_editing_rule: false
+promoted_from: null
+created: "2026-05-14T00:00:00Z"
+last_modified: "2026-05-14T00:00:00Z"

--- a/tests/test_a2_correction.py
+++ b/tests/test_a2_correction.py
@@ -1,0 +1,262 @@
+"""
+tests/test_a2_correction.py
+
+Focused test for the A2 corrected minimality sketch.
+
+Validates:
+ 1. cl-003-a2-correction.yaml is a well-formed C1 ClaimLedgerEntry.
+ 2. docs/a2-corrected-minimality-sketch.md contains the three required
+    correction statements:
+    (a) cubic invariant on C^3 withdrawn;
+    (b) Hermitian + alternating volume form as replacement, with no
+        symmetric bilinear admitted as an additional replacement;
+    (c) non-theorem / non-YM-mass-gap boundary explicit.
+
+These assertions correspond to the review-mandated corrections:
+ - d_{abc} on defining rep C^3 is wrong; it lives on the adjoint, dim 8;
+ - correct invariant data for SU(3) on V_A=C^3 are H_A plus epsilon in wedge^3 V*;
+ - the sketch is not a theorem and does not close the Yang-Mills mass gap.
+"""
+
+from pathlib import Path
+import re
+import warnings
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).parent.parent
+FIXTURE_PATH = REPO_ROOT / "fixtures" / "valid" / "cl-003-a2-correction.yaml"
+SKETCH_PATH = REPO_ROOT / "docs" / "a2-corrected-minimality-sketch.md"
+
+
+@pytest.fixture
+def cl003_fixture():
+    assert FIXTURE_PATH.exists(), (
+        f"Fixture not found: {FIXTURE_PATH}. "
+        f"Expected cl-003-a2-correction.yaml in fixtures/valid/."
+    )
+    with open(FIXTURE_PATH, encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+@pytest.fixture
+def sketch_text():
+    assert SKETCH_PATH.exists(), (
+        f"Correction sketch not found: {SKETCH_PATH}. "
+        f"Expected a2-corrected-minimality-sketch.md in docs/."
+    )
+    return SKETCH_PATH.read_text(encoding="utf-8")
+
+
+class TestCL003FixtureSchema:
+    def test_fixture_loads(self, cl003_fixture):
+        assert cl003_fixture is not None
+
+    def test_claim_id(self, cl003_fixture):
+        assert cl003_fixture.get("claim_id") == "CL-003", (
+            f"Expected claim_id='CL-003'. Got: {cl003_fixture.get('claim_id')!r}"
+        )
+
+    def test_claim_class_is_c1(self, cl003_fixture):
+        assert cl003_fixture.get("claim_class") == "C1", (
+            f"A2 correction must be C1 (analytically grounded). "
+            f"Got: {cl003_fixture.get('claim_class')!r}. "
+            f"C2 would require a RunReceipt; no computation is claimed here."
+        )
+
+    def test_no_run_receipts(self, cl003_fixture):
+        receipts = cl003_fixture.get("run_receipt_ids", [])
+        assert len(receipts) == 0, (
+            f"C1 claim must have no run_receipt_ids. Got: {receipts}"
+        )
+
+    def test_no_run_trace_artifacts(self, cl003_fixture):
+        run_trace_types = {
+            "CandidateTrace",
+            "ChannelTrace",
+            "ScoreTrace",
+            "ObservableTrace",
+            "ResidualTrace",
+            "RunReceipt",
+        }
+        artifact_refs = cl003_fixture.get("artifact_refs", [])
+        bad = [ref for ref in artifact_refs if ref.get("artifact_type") in run_trace_types]
+        assert len(bad) == 0, f"C1 claim cannot reference run-trace artifacts: {bad}"
+
+    def test_stage2_not_claimed(self, cl003_fixture):
+        statement = cl003_fixture.get("statement", "")
+        forbidden_phrases = [
+            "proves A2",
+            "confirms theorem",
+            "establishes naturality",
+            "I-12 eligible",
+            "YM mass gap",
+            "mass gap closed",
+            "Yang-Mills proven",
+        ]
+        for phrase in forbidden_phrases:
+            assert phrase.lower() not in statement.lower(), (
+                f"Fixture statement contains forbidden phrase: {phrase!r}. "
+                f"This is a C1 correction note, not a theorem."
+            )
+
+    def test_manuscript_editing_rule_set(self, cl003_fixture):
+        rule = cl003_fixture.get("manuscript_editing_rule")
+        assert rule is True, (
+            f"manuscript_editing_rule should be true: the original d-symbol-on-C^3 "
+            f"claim is forbidden from manuscript theorem statements. Got: {rule!r}"
+        )
+
+    def test_required_fields_present(self, cl003_fixture):
+        required = ["claim_id", "claim_class", "statement"]
+        for field in required:
+            assert field in cl003_fixture, f"Missing required field: {field!r}"
+
+
+class TestSketchCorrectionContent:
+    def test_sketch_loads(self, sketch_text):
+        assert len(sketch_text.strip()) > 0
+
+    def test_correction_a_cubic_invariant_withdrawn(self, sketch_text):
+        text_lower = sketch_text.lower()
+        required_signals = [
+            "cubic",
+            "fundamental",
+            "adjoint",
+        ]
+        for signal in required_signals:
+            assert signal in text_lower, (
+                f"Correction (a) incomplete: expected signal {signal!r}. "
+                f"The sketch must distinguish the adjoint cubic tensor from the "
+                f"SU(3) fundamental representation."
+            )
+        withdrawal_signals = ["withdrawn", "false", "incorrect", "not `c^3`", "not c^3"]
+        assert any(signal in text_lower for signal in withdrawal_signals), (
+            "Correction (a) not found: the sketch must explicitly withdraw or reject "
+            "the cubic invariant claim on the SU(3) fundamental."
+        )
+
+    def test_correction_b_hermitian_alternating_volume_replacement(self, sketch_text):
+        text_lower = sketch_text.lower()
+        hermitian_signals = ["hermitian", "h_a", "h(v,w)"]
+        assert any(sig in text_lower for sig in hermitian_signals), (
+            "Correction (b) incomplete: replacement invariant data must include "
+            "the Hermitian form H_A."
+        )
+
+        volume_signals = [
+            "alternating",
+            "volume form",
+            "determinant",
+            "wedge^3",
+            "lambda^3",
+            "\\lambda^3",
+            "λ³",
+            "Λ³".lower(),
+            "epsilon",
+            "ε",
+        ]
+        assert any(sig.lower() in text_lower for sig in volume_signals), (
+            "Correction (b) incomplete: replacement invariant data must include "
+            "the alternating determinant/volume form epsilon in wedge^3 V*."
+        )
+
+        # The correction is allowed, and indeed required, to mention symmetric
+        # bilinear forms as excluded structure. It must not propose such a form
+        # as a replacement invariant.
+        forbidden_patterns = [
+            r"replacement[^.]{0,80}symmetric\s+bilinear",
+            r"symmetric\s+bilinear[^.]{0,80}replacement",
+            r"preserves[^.]{0,80}symmetric\s+bilinear",
+        ]
+        for pattern in forbidden_patterns:
+            assert not re.search(pattern, text_lower), (
+                "Correction (b) violation: sketch appears to propose a symmetric "
+                "bilinear form as replacement. Correct replacement is Hermitian "
+                "+ alternating volume, with symmetric bilinear explicitly excluded."
+            )
+
+        exclusion_signals = [
+            "no additional symmetric bilinear",
+            "does not preserve any symmetric bilinear",
+            "no symmetric bilinear",
+            "exclude that orthogonal structure",
+        ]
+        assert any(sig in text_lower for sig in exclusion_signals), (
+            "Correction (b) incomplete: the sketch must explicitly exclude the "
+            "symmetric bilinear / orthogonal branch."
+        )
+
+    def test_correction_c_non_theorem_non_ym_mass_gap_boundary(self, sketch_text):
+        text_lower = sketch_text.lower()
+        boundary_signals = [
+            "non-claim",
+            "does not claim",
+            "does not prove",
+            "not a theorem",
+            "not a proof",
+            "sketch-level",
+            "boundary",
+        ]
+        assert any(sig in text_lower for sig in boundary_signals), (
+            "Correction (c) not found: the sketch must carry explicit non-theorem "
+            "and non-Yang-Mills-mass-gap boundary language."
+        )
+
+        ym_signals = ["yang--mills", "yang-mills", "mass-gap", "mass gap", "ym"]
+        if any(sig in text_lower for sig in ym_signals):
+            negation_signals = [
+                "not",
+                "does not",
+                "no claim",
+                "outside scope",
+                "non-claim",
+                "boundary",
+            ]
+            ym_with_negation = False
+            for ym_sig in ym_signals:
+                for match in re.finditer(re.escape(ym_sig), text_lower):
+                    start = max(0, match.start() - 200)
+                    end = min(len(text_lower), match.end() + 200)
+                    window = text_lower[start:end]
+                    if any(neg in window for neg in negation_signals):
+                        ym_with_negation = True
+                        break
+            assert ym_with_negation, (
+                "Correction (c): Yang-Mills or mass gap is mentioned but not in "
+                "a clear non-claim context."
+            )
+
+
+class TestFixtureSketchConsistency:
+    def test_fixture_statement_consistent_with_corrections(self, cl003_fixture):
+        statement = cl003_fixture.get("statement", "")
+        forbidden = [
+            "d-symbol on c^3",
+            "d-symbol on c³",
+            "d_{abc} on the defining",
+            "symmetric cubic on v_a",
+            "dim v_a = milnor",
+        ]
+        for phrase in forbidden:
+            assert phrase.lower() not in statement.lower(), (
+                f"Fixture statement contains language from the original incorrect claim: "
+                f"{phrase!r}."
+            )
+
+    def test_fixture_references_sketch_or_operator(self, cl003_fixture):
+        artifact_refs = cl003_fixture.get("artifact_refs", [])
+        operator_refs = cl003_fixture.get("operator_refs", [])
+        has_evidence = len(artifact_refs) > 0 or len(operator_refs) > 0
+        if not has_evidence:
+            warnings.warn(
+                "CL-003 has no artifact_refs or operator_refs. A correction claim "
+                "should reference its evidence basis.",
+                UserWarning,
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds a controlled correction note for the A2 minimality sketch and wires it into the claim-ledger/test surface.

## Adds

- `docs/a2-corrected-minimality-sketch.md`
- `fixtures/valid/cl-003-a2-correction.yaml`
- `tests/test_a2_correction.py`

## Correction

The prior cubic-invariant-on-`C^3` framing is withdrawn. The corrected A2 fundamental-representation invariant data is:

```text
Hermitian form + alternating volume form + explicit no-symmetric-bilinear exclusion
```

The note states that the adjoint `d^{abc}` tensor lives on the adjoint representation, not on the SU(3) defining representation `C^3`.

## Boundaries

This PR does not claim:

- A2 minimality is proved;
- the A2 Spin-target is selected;
- the A1 proof transfers automatically to A2;
- the `SU(2) x SU(3)` product gate is proved;
- any Yang-Mills mass-gap consequence.

## Tests

The new focused test validates:

- CL-003 fixture is a C1 correction entry;
- the fixture carries `manuscript_editing_rule: true`;
- no run receipts or run-trace artifacts are referenced;
- the correction note withdraws the cubic/fundamental framing;
- the correction note contains Hermitian + alternating-volume replacement language;
- the correction note excludes symmetric bilinear structure rather than proposing it;
- the correction note preserves non-theorem / non-Yang-Mills-mass-gap boundaries.

The test is adapted from the uploaded review test, with a guard refined so that correct `no symmetric bilinear` exclusion language is allowed while replacement/proposal language is rejected.