### PR TITLE
chore: advance Candidate C PFK pin to Heller-Godel registry expansion

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -7,29 +7,34 @@ Claim level: governance / architecture.
 
 | Repository | Commit SHA | Cited content |
 |---|---|---|
-| `SocioProphet/Heller-Godel` | `0ef1cab4c525fd004e38fa9a92f7e911acbbc976` | Framework objects from `docs/framework-core/` and PFK objects from `proof_fabric_kernel/` |
+| `SocioProphet/Heller-Godel` | `988307215ad38ccb16514311222184a1b757752b` | Framework objects (`HG-*`) from `docs/framework-core/`; PFK objects (`PFK-*`) from `proof_fabric_kernel/` |
 
 ## Cited framework objects
 
 | Identifier | Use | Citation grade |
 |---|---|---|
 | `HG-EX-001` | Catalan / mu_2 fixture reference | fixture-grade |
-| `HG-MTH-001` | Framework-core distance classification | method-grade |
-| `HG-MTH-002` | Claim grammar and citation rule | method-grade |
-| `HG-MTH-003` | Dependency graph | method-grade |
-| `HG-MTH-004` | Anti-seed framework register | method-grade |
+| `HG-MTH-005` | Universal Bridge formal specification | method-grade; no proof transfer |
 
 ## Cited PFK surfaces
 
-| Surface | Path | Use |
+| Identifier / surface | Path | Use |
 |---|---|---|
-| Event-IR schema | `proof_fabric_kernel/schemas/event_ir.schema.json` | Candidate C operator-event traces |
-| ProofArtifact schema | `proof_fabric_kernel/schemas/proof_artifact.schema.json` | Candidate C proof-artifact envelope |
-| Claim-ledger schema | `proof_fabric_kernel/schemas/claim_ledger_row.schema.json` | Candidate C descriptive-grade claim row |
-| Calibration-bundle schema | `proof_fabric_kernel/schemas/calibration_bundle.schema.json` | Candidate C baseline calibration bundle |
-| PrimeStatsProtocol | `proof_fabric_kernel/docs/PrimeStatsProtocol_v1.md` | N1/N2/S1/S2/S3 protocol vocabulary |
-| Operator catalog | `proof_fabric_kernel/docs/OperatorCatalog_PrimePolicyOperators_v1.md` | PFK operator identifiers |
+| `PFK-SCHEMA-002` | `proof_fabric_kernel/schemas/event_ir.schema.json` | Candidate C operator-event traces |
+| `PFK-SCHEMA-003` | `proof_fabric_kernel/schemas/proof_artifact.schema.json` | Candidate C proof-artifact envelope |
+| `PFK-SCHEMA-001` | `proof_fabric_kernel/schemas/claim_ledger_row.schema.json` | Candidate C descriptive-grade claim row |
+| `PFK-SCHEMA-004` | `proof_fabric_kernel/schemas/calibration_bundle.schema.json` | Candidate C baseline calibration bundle |
+| `PFK-OP-031` | `proof_fabric_kernel/docs/OperatorCatalog_PrimePolicyOperators_v1.md` | log-phase embedding |
+| `PFK-OP-032` | `proof_fabric_kernel/docs/OperatorCatalog_PrimePolicyOperators_v1.md` | mean resultant length R |
+| `PFK-OP-051..055` | `proof_fabric_kernel/docs/OperatorCatalog_PrimePolicyOperators_v1.md` | N1/N2/S1/S2/S3 protocol operators |
+| `A-PFK-*` | `proof_fabric_kernel/docs/anti-seed-pfk.md` | operational anti-seed boundary |
+
+## Local PFK status
+
+Current `main` has no committed local `proof_fabric_kernel/` tree to delete. Earlier source-location audits found PFK source provenance and Heller-Godel now hosts the canonical PFK surface. Heller-Winters consumes PFK exclusively from Heller-Godel at the pinned commit above.
+
+This PR advances the pin from initial PFK seed import `0ef1cab4c525fd004e38fa9a92f7e911acbbc976` to registry expansion `988307215ad38ccb16514311222184a1b757752b`. The advance is non-breaking because schema files are unchanged; the registry expansion canonicalizes identifiers already used by Candidate C.
 
 ## Non-claim boundary
 
-Declaring this dependency does not promote Candidate C, RH, GRH, zero-location, residual-envelope, or asymptotic claims.
+Declaring this dependency does not promote Candidate C, RH, GRH, zero-location, residual-envelope, or asymptotic claims. Green PFK validation is receipt-loop closure only, not theorem-grade evidence.

--- a/experiments/candidate-c/README.md
+++ b/experiments/candidate-c/README.md
@@ -6,7 +6,7 @@ Claim class: descriptive-grade infrastructure claim.
 This experiment demonstrates that Candidate C can emit PFK-compatible receipts against the Heller-Godel canonical PFK surface at:
 
 ```text
-SocioProphet/Heller-Godel @ 0ef1cab4c525fd004e38fa9a92f7e911acbbc976
+SocioProphet/Heller-Godel @ 988307215ad38ccb16514311222184a1b757752b
 ```
 
 ## Scope
@@ -40,3 +40,7 @@ python3 tests/test_candidate_c_emission.py
 ## Non-claims
 
 This artifact does not claim RH, GRH, zero-location control, residual-envelope control, asymptotic convergence, or statistical novelty. It proves only that the native PFK receipt loop can close for Candidate C.
+
+## Pin advance note
+
+This experiment originally landed against Heller-Godel `0ef1cab4c525fd004e38fa9a92f7e911acbbc976`, the initial in-repo PFK seed-tree merge. It now cites `988307215ad38ccb16514311222184a1b757752b`, the PFK registry-expansion merge that canonicalized the granular operator IDs and PFK anti-seed register without changing schema files.

--- a/experiments/candidate-c/run.py
+++ b/experiments/candidate-c/run.py
@@ -9,7 +9,7 @@ import random
 from pathlib import Path
 from typing import Sequence
 
-UPSTREAM_SHA = "0ef1cab4c525fd004e38fa9a92f7e911acbbc976"
+UPSTREAM_SHA = "988307215ad38ccb16514311222184a1b757752b"
 LIMIT = 10000
 SEED = 20260510
 FREQUENCIES = [1.0, 2.0, 3.0]

--- a/tests/test_candidate_c_emission.py
+++ b/tests/test_candidate_c_emission.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import importlib.util
 import json
 import subprocess
 import sys
@@ -10,7 +9,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 RUNNER = ROOT / "experiments" / "candidate-c" / "run.py"
-UPSTREAM_SHA = "0ef1cab4c525fd004e38fa9a92f7e911acbbc976"
+UPSTREAM_SHA = "988307215ad38ccb16514311222184a1b757752b"
 
 REQUIRED_EVENT_KEYS = {"id", "kind", "scope", "time", "props"}
 REQUIRED_ARTIFACT_KEYS = {"artifact_id", "artifact_type", "claim_class", "inputs", "outputs", "non_claim_boundary"}


### PR DESCRIPTION
## Summary

Cleanup PR advancing Heller-Winters Candidate C and `DEPENDENCIES.md` from the initial Heller-Godel PFK seed-tree pin `0ef1cab4c525fd004e38fa9a92f7e911acbbc976` to the PFK registry-expansion pin `988307215ad38ccb16514311222184a1b757752b`.

This is the real current-state cleanup: current `main` has no committed local `proof_fabric_kernel/` tree to delete, so this PR does not delete phantom files. It records Heller-Winters as consuming canonical PFK exclusively from Heller-Godel.

## What changed

- Updates `DEPENDENCIES.md` to pin `SocioProphet/Heller-Godel @ 988307215ad38ccb16514311222184a1b757752b`.
- Updates `experiments/candidate-c/run.py` `UPSTREAM_SHA` to `9883072...`.
- Updates `tests/test_candidate_c_emission.py` expected upstream SHA.
- Updates `experiments/candidate-c/README.md` to document the pin advance.

## Why this is non-breaking

Heller-Godel PR #67 was a registry expansion. It canonicalized granular PFK operator IDs, schema IDs, and PFK anti-seed entries. It did not change PFK schema files, so Candidate C receipt shape remains valid.

## What this PR does not do

- Does not change Candidate C scope.
- Does not emit new receipts into the repo.
- Does not promote any claim grade.
- Does not advance the substantive half of HW Issue #28.
- Does not claim RH, GRH, zero-location, asymptotic, or theorem-grade evidence.

## CI gating

Existing Heller-Winters workflows should continue to pass, including Candidate C native PFK emission.

## Follows from

- Heller-Winters PR #39 — Candidate C native PFK emission @ `75ce9c68eea01211ac5683c38773011be96e3f41`.
- Heller-Godel PR #65 — initial PFK seed tree @ `0ef1cab4c525fd004e38fa9a92f7e911acbbc976`.
- Heller-Godel PR #67 — PFK registry expansion @ `988307215ad38ccb16514311222184a1b757752b`.
- np-program PR #35 — canonical PFK migration @ `ec2962af7f4aa841973bf24246f53aa95b280037`.