### PR TITLE
feat: absorb hphd-zeta-mirror-lattice as lanes/hphd

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The controlled lane inventory is maintained in `docs/programme-lane-map.md`. At 
 3. spectral zeta regularization;
 4. descent/topos semantics;
 5. information-geometric learning dynamics;
-6. the subordinate prime/operator lane.
+6. the subordinate prime/operator lane;
+7. `lanes/hphd/` — HPHD zeta mirror-lattice RH-method lane, absorbed from `SocioProphet/hphd-zeta-mirror-lattice`.
 
 ## Defensible mathematical spine
 
@@ -136,6 +137,12 @@ The companion governance artifacts are:
 
 This lane remains active, but it is no longer the sole README framing. It is one research substrate inside the larger Heller–Winters coherence programme.
 
+## HPHD zeta mirror-lattice lane
+
+`lanes/hphd/` hosts the absorbed HPHD zeta mirror-lattice RH-method lane. It contains the trivial-zero mirror-lattice thesis, explicit-formula typing gate, and finite-window Richter saturation SPEC note inherited from `SocioProphet/hphd-zeta-mirror-lattice`.
+
+This lane is methodology and explicit-formula infrastructure. It does not prove RH, GRH, BSD, or any asymptotic theorem. The standalone `hphd-zeta-mirror-lattice` repository is retained as provenance and should redirect here after the companion archive PR merges.
+
 ## Repository-name note
 
 The GitHub repository may still appear as `Heller-Winters-Theorem` for continuity with earlier work. That repository name is historical and aspirational. The canonical conceptual object is the **Heller–Winters Programme**. The word “theorem” is reserved for future, formally stated and proved results inside the programme.
@@ -148,7 +155,9 @@ Other SocioProphet repositories may use Heller methodology without being lanes o
 
 Default policy: **minimalist unless explicitly promoted.** A repo is not inside the Heller–Winters Programme merely because it shares methodology, vocabulary, or proof discipline.
 
-Candidate repos such as `yang-mills`, `np-program`, `bsd-proof-program`, `Heller-Godel`, and `hphd-zeta-mirror-lattice` must be classified explicitly before they are treated as programme lanes. Relationship classes are defined in `docs/programme-lane-map.md`.
+Candidate repos such as `yang-mills`, `np-program`, `bsd-proof-program`, and `Heller-Godel` must be classified explicitly before they are treated as programme lanes. Relationship classes are defined in `docs/programme-lane-map.md`.
+
+`hphd-zeta-mirror-lattice` is no longer a candidate external relationship: its current documentation lane has been absorbed into `lanes/hphd/`.
 
 ## Current canonical documents
 
@@ -163,4 +172,5 @@ Candidate repos such as `yang-mills`, `np-program`, `bsd-proof-program`, `Heller
 - `docs/prime-operator-lane/operator-registry-v0.1.md` — typed operator registry for the prime/operator lane.
 - `docs/prime-operator-lane/claim-ledger-v0.1.md` — claim ledger and promotion/downgrade rules for prime/operator-lane prose and artifacts.
 - `docs/prime-operator-lane/artifact-schema-v0.1.md` — evidence artifact schema for run, trace, figure, proof, and ledger artifacts.
+- `lanes/hphd/` — HPHD zeta mirror-lattice RH-method lane, including absorbed docs `01..05`.
 - `empirical-claims/phase-gate-null-X1e6/` — Candidate C executable empirical artifact package.

--- a/lanes/hphd/01-negative-mirror-lattice.md
+++ b/lanes/hphd/01-negative-mirror-lattice.md
@@ -1,0 +1,414 @@
+# Negative Mirror Lattices, Trivial Zeros, and Regularized Density
+
+Status: Draft v0.1  
+Lane: HPHD / zeta mirror-lattice / BSD-adjacent analytic-number-theory program  
+Purpose: Capture the refined manuscript version of the HPHD interpretation of trivial zeros, non-trivial zeros, negative mirror lattices, and zeta-regularized density.
+
+## 1. Core thesis
+
+The trivial zeros of the Riemann zeta function should not be dismissed as mathematically uninteresting. They are "trivial" only because their location is rigid, explicit, and structurally forced. Conceptually, they occupy an important role: they form a negative-side mirror lattice inside the analytically continued zeta system.
+
+The non-trivial zeros encode the irregular harmonic fluctuation of prime distribution. The trivial zeros encode a regular cancellation scaffold on the negative side of the completed function. Together, they show that the zeta function is not merely a machine for counting primes, but a symmetry-bearing object whose positive, negative, finite, infinite, regular, and irregular regimes are coupled through analytic continuation.
+
+The HPHD refinement is therefore:
+
+```math
+\text{prime harmonic structure}
+=
+\text{main growth}
++
+\text{non-trivial fluctuation spectrum}
++
+\text{trivial-zero mirror lattice}
++
+\text{regularized density shadow}.
+```
+
+This preserves the original intuition while correcting the claim boundary. We should not say, literally, that the trivial zeros are "negative primes." We should say that they are the negative mirror-lattice of the completed zeta structure: a regular cancellation domain paired against the irregular prime-governing spectrum of the non-trivial zeros.
+
+## 2. Standard zeta substrate
+
+The Riemann zeta function begins in the ordinary convergent region as
+
+```math
+\zeta(s)=\sum_{n=1}^{\infty} n^{-s},
+\qquad \Re(s)>1.
+```
+
+In this region, `zeta(s)` is directly tied to the positive integers and, through Euler's product,
+
+```math
+\zeta(s)=\prod_p \frac{1}{1-p^{-s}},
+```
+
+to the primes.
+
+The deeper object is not only this convergent series. The deeper object is the analytic continuation of `zeta(s)` to the complex plane, except for a simple pole at `s=1`. Once we move into analytic continuation, the negative side of the complex plane becomes meaningful. It is not meaningful as an ordinary infinite sum. It is meaningful as part of the completed analytic object.
+
+This distinction matters. The negative values of `zeta(s)`, the trivial zeros, and the regularized values of divergent series do not belong to elementary summation. They belong to analytic continuation, functional equations, and regularization.
+
+## 3. Trivial and non-trivial zeros
+
+The zeros of `zeta(s)` divide into two major families.
+
+The trivial zeros occur at the negative even integers:
+
+```math
+s=-2,-4,-6,\ldots
+```
+
+Equivalently:
+
+```math
+s=-2n,\qquad n\in\mathbb N.
+```
+
+The non-trivial zeros occur in the critical strip:
+
+```math
+0<\Re(s)<1.
+```
+
+The Riemann hypothesis asserts that every non-trivial zero lies on the critical line:
+
+```math
+\Re(s)=\frac12.
+```
+
+The trivial zeros are rigid, regular, and linearly spaced. The non-trivial zeros are irregular, complex, and encode deep information about the distribution of primes.
+
+The improved contrast is:
+
+```math
+\text{trivial zeros}=\text{regular negative mirror lattice},
+```
+
+```math
+\text{non-trivial zeros}=\text{irregular positive-prime fluctuation spectrum}.
+```
+
+The word "trivial" is therefore misleading from the HPHD perspective. These zeros are trivial only in the sense that they are explicitly located. Structurally, they are not trivial. They mark the negative-side cancellation pattern required by the functional symmetry of the zeta function.
+
+## 4. Functional equation and mirror lattice
+
+The completed zeta system possesses a symmetry relating `s` and `1-s`. A standard completed form is:
+
+```math
+\xi(s)
+=
+\frac12 s(s-1)\pi^{-s/2}\Gamma(s/2)\zeta(s),
+```
+
+with the symmetry:
+
+```math
+\xi(s)=\xi(1-s).
+```
+
+This completion absorbs the pole at `s=1`, packages the Gamma factor, and reveals the deep reflection symmetry of zeta.
+
+The trivial zeros of `zeta(s)` at negative even integers are tied to the trigonometric/Gamma architecture of the functional equation. More precisely, the vanishing at negative even integers is directly exposed by the sine factor in an equivalent functional equation. The better anatomical statement is:
+
+> The Gamma factor participates in the completed symmetry, but the negative-even vanishing of `zeta(s)` is most directly forced by the trigonometric factor appearing in the functional equation.
+
+This matters because it prevents us from misdescribing the mechanism. The trivial zeros are not arbitrary negative points. They are forced cancellation points in the completed analytic architecture.
+
+Define the zeta mirror lattice:
+
+```math
+\mathcal M^-_{\zeta}=\{-2n:n\in\mathbb N\}.
+```
+
+This is the negative-side regular lattice of zeta cancellation.
+
+## 5. Why "negative primes" is useful but dangerous
+
+In ordinary number theory, a negative prime would simply mean `-p`, where `p` is a positive prime. That is not what the original intuition was reaching for.
+
+The trivial zeros are not located at:
+
+```math
+-2,-3,-5,-7,-11,\ldots
+```
+
+They are located at:
+
+```math
+-2,-4,-6,-8,\ldots
+```
+
+So they are not "negative primes" in the ordinary arithmetic sense.
+
+The better HPHD term is:
+
+```text
+negative mirror-lattice carriers
+```
+
+or, more compactly:
+
+```text
+mirror-lattice zeros
+```
+
+We may preserve "negative primes" as a metaphor only if it is typed correctly:
+
+> "Negative primes" does not mean prime numbers on the negative axis. It means the negative-side analytic counterstructure that balances the positive-prime harmonic system through the completed zeta function.
+
+Unsafe version:
+
+```text
+The trivial zeros are negative primes.
+```
+
+Safe version:
+
+```text
+The trivial zeros behave, within HPHD, as a negative mirror-lattice counterpart to the prime-governed oscillatory spectrum.
+```
+
+## 6. Density correction
+
+The trivial zeros and non-trivial zeros do not have the same density in the ordinary sense.
+
+The trivial zeros are evenly spaced:
+
+```math
+-2,-4,-6,\ldots
+```
+
+Their counting function along the negative real axis is approximately:
+
+```math
+N_{\mathrm{triv}}(R)\sim \frac{R}{2}.
+```
+
+The non-trivial zeros have a different asymptotic density. The number of non-trivial zeros with imaginary part between `0` and `T` grows approximately like:
+
+```math
+N_{\mathrm{nt}}(T)
+\sim
+\frac{T}{2\pi}\log\frac{T}{2\pi}
+-
+\frac{T}{2\pi}.
+```
+
+Therefore we must not say:
+
+```math
+N_{\mathrm{triv}}(R)\sim N_{\mathrm{nt}}(T)
+```
+
+without additional structure.
+
+The correct HPHD move is to introduce an embedding or measure transformation. The trivial-zero lattice and the non-trivial-zero spectrum may become comparable only after a specified embedding, reparameterization, spectral index, or pushforward measure.
+
+Formally, introduce a map:
+
+```math
+\Phi:\mathcal M^-_{\zeta}\to Z_{\mathrm{nt}},
+```
+
+or more generally a measure transport:
+
+```math
+\Phi_*\mu_{\mathrm{triv}}\sim \mu_{\mathrm{nt}},
+```
+
+where:
+
+```math
+\mu_{\mathrm{triv}}=\sum_{n\ge1}\delta_{-2n},
+```
+
+and:
+
+```math
+\mu_{\mathrm{nt}}=\sum_{\rho\in Z_{\mathrm{nt}}}\delta_{\rho}.
+```
+
+This does not assert equality. It asserts that HPHD must define the comparison layer before claiming a balance of density.
+
+## 7. Divergent series and regularized negative density
+
+The series:
+
+```math
+1+1+1+1+\cdots
+```
+
+diverges in the ordinary sense. It does not equal `-1/2` as an ordinary sum.
+
+However, under zeta regularization:
+
+```math
+1+1+1+1+\cdots
+\overset{\zeta\text{-reg}}{=}
+\zeta(0)
+=
+-\frac12.
+```
+
+Similarly:
+
+```math
+1+2+3+4+\cdots
+\overset{\zeta\text{-reg}}{=}
+\zeta(-1)
+=
+-\frac1{12}.
+```
+
+These are not ordinary sums. They are regularized invariants.
+
+The negative value is not saying that infinitely many positive ones literally add to `-1/2`. It is saying that when divergent positive density is passed through analytic continuation, the completed system assigns it a finite shadow value.
+
+HPHD can therefore use the typed transformation:
+
+```text
+ordinary divergent density -> regularized negative invariant
+```
+
+This gives a disciplined meaning to "negative density." It is not physical negative quantity by default. It is not arithmetic negativity by default. It is a renormalized analytic residue of an infinite positive structure.
+
+In HPHD language:
+
+> The negative domain is the shadow domain where infinite positive accumulation is compressed into finite regularized invariants.
+
+## 8. Explicit-formula interpretation
+
+The strongest mathematical bridge is the explicit-formula tradition.
+
+Prime distribution is not governed only by the primes themselves. It is governed by analytic structure: poles, zeros, and correction terms of zeta-like functions.
+
+A simplified HPHD decomposition is:
+
+```math
+\pi(x)
+\approx
+\text{main growth from the pole at }s=1
+-
+\text{oscillations from non-trivial zeros}
++
+\text{corrections from trivial zeros and completion terms}.
+```
+
+More schematically:
+
+```math
+\text{prime counting}
+=
+\text{smooth term}
++
+\text{zero spectrum}
++
+\text{completion corrections}.
+```
+
+The pole at `s=1` gives the main growth. The non-trivial zeros give oscillatory corrections. The trivial zeros and completion terms contribute background correction structure.
+
+This is the rigorous version of the earlier "prime music and bassline" metaphor.
+
+Refined phrasing:
+
+> The non-trivial zeros form the fluctuation spectrum controlling prime-counting error, while the trivial zeros form a completion-induced mirror lattice contributing regular correction structure on the negative side.
+
+## 9. HPHD integration: ball, mirror, boundary
+
+The HPHD framework works with the relationship among:
+
+```math
+0,\quad n,\quad \infty,
+```
+
+and their associated boundary, density, and embedding behavior.
+
+The zeta system gives a natural analytic model for this.
+
+The ordinary Dirichlet series begins in the finite-positive regime:
+
+```math
+\sum_{n=1}^{\infty}n^{-s}.
+```
+
+The Euler product exposes the prime multiplicative skeleton:
+
+```math
+\prod_p(1-p^{-s})^{-1}.
+```
+
+Analytic continuation extends the system beyond the ordinary region of convergence. The functional equation reflects the system across a symmetry boundary. The trivial zeros appear on the negative side as a rigid cancellation lattice. The non-trivial zeros appear in the critical strip as the irregular fluctuation spectrum. Zeta regularization assigns finite negative values to certain divergent positive densities.
+
+So the HPHD structure becomes:
+
+```text
+positive finite arithmetic
+-> infinite accumulation
+-> analytic continuation
+-> negative mirror lattice
+-> regularized density invariant
+```
+
+The ball principle can then be stated as:
+
+> Every positive arithmetic domain carries, through analytic continuation and completion, a mirrored negative-side structure. This mirror is not a naive copy. It is a transformed domain of cancellation, regularization, and spectral correction.
+
+Thus, the negative side is not an absence. It is a structured completion boundary.
+
+## 10. Extension beyond zeta: Dirichlet L-functions
+
+The zeta function is the base case. HPHD should not stop there.
+
+Once we move from all integers/primes into residue classes modulo `m`, the correct analytic objects become Dirichlet L-functions:
+
+```math
+L(s,\chi)=\sum_{n=1}^{\infty}\frac{\chi(n)}{n^s}.
+```
+
+These functions decompose arithmetic by character, parity, and residue structure.
+
+This matters because trivial-zero patterns change depending on the parity and completion data of the character `chi`. Therefore, the negative mirror lattice is not always simply:
+
+```math
+-2,-4,-6,\ldots
+```
+
+That is the mirror lattice for the base zeta case.
+
+For a more general `L(s, chi)`, the mirror-side cancellation structure depends on the completed L-function.
+
+The upgraded HPHD principle is:
+
+> Every completed arithmetic harmonic object carries its own mirror lattice, determined by its functional equation, parity, and completion data.
+
+This gives HPHD a path from:
+
+```text
+zeta(s) -> L(s, chi) -> residue-class harmonic geometry -> modular prime-density structure
+```
+
+## 11. Final formulation
+
+The completed zeta function reveals that arithmetic has both a positive-prime harmonic face and a negative mirror-cancellation face. The positive face appears through the Euler product and the distribution of primes. The fluctuation structure appears through the non-trivial zeros. The negative mirror face appears through the trivial zeros and through zeta-regularized values of divergent positive densities.
+
+The trivial zeros are therefore not conceptually disposable. They are the regular lattice of analytic cancellation required by completion. They mark the structured negative side of the zeta system.
+
+In HPHD terms:
+
+```math
+\boxed{\text{The trivial zeros are the fixed mirror lattice of zeta completion.}}
+```
+
+```math
+\boxed{\text{The non-trivial zeros are the fluctuation spectrum of prime irregularity.}}
+```
+
+```math
+\boxed{\text{Zeta-regularized negative values are finite shadows of divergent positive density.}}
+```
+
+Together, these define a disciplined negative-domain model:
+
+```math
+\boxed{\text{negative domain}=\text{mirror lattice}+\text{completion correction}+\text{regularized density shadow}.}
+```

--- a/lanes/hphd/02-formal-claims.md
+++ b/lanes/hphd/02-formal-claims.md
@@ -1,0 +1,286 @@
+# Formal Claims, Guardrails, and Conjectural Objects
+
+Status: Draft v0.1  
+Lane: HPHD / zeta mirror-lattice / formal claim boundary  
+Purpose: Convert the HPHD zeta mirror-lattice intuition into typed definitions, lemmas, conjectures, and admissible research claims.
+
+## 1. Core objects
+
+### Definition 1: Zeta mirror lattice
+
+The zeta mirror lattice is:
+
+```math
+\mathcal M^-_{\zeta}=\{-2n:n\in\mathbb N\}.
+```
+
+It is the set of trivial zeros of the Riemann zeta function.
+
+### Definition 2: Non-trivial zeta fluctuation spectrum
+
+The non-trivial zeta spectrum is:
+
+```math
+Z_{\mathrm{nt}}
+=
+\{\rho\in\mathbb C:\zeta(\rho)=0,\ 0<\Re(\rho)<1\}.
+```
+
+The Riemann hypothesis asserts:
+
+```math
+\rho\in Z_{\mathrm{nt}}\Rightarrow \Re(\rho)=\frac12.
+```
+
+HPHD does not assume RH as proven. HPHD may study the consequences of the critical-line hypothesis as a conditional branch.
+
+### Definition 3: Regularized density value
+
+A divergent series `S` may be assigned a zeta-regularized value only when a specified analytic-continuation procedure assigns such a value.
+
+We write:
+
+```math
+S\overset{\zeta\text{-reg}}{=}a
+```
+
+to distinguish this from ordinary convergence.
+
+### Definition 4: HPHD mirror domain
+
+An HPHD mirror domain is a transformed negative-side structure induced by continuation, completion, reflection, or renormalization from a positive arithmetic source domain.
+
+For the base zeta function, the canonical first example is:
+
+```math
+\mathcal M^-_{\zeta}.
+```
+
+### Definition 5: Admissible density comparison
+
+A density comparison between two spectra or lattices is admissible only when the measure, coordinate, and transformation are explicit.
+
+For example, one may define:
+
+```math
+\mu_{\mathrm{triv}}=\sum_{n\ge1}\delta_{-2n}
+```
+
+and:
+
+```math
+\mu_{\mathrm{nt}}=\sum_{\rho\in Z_{\mathrm{nt}}}\delta_{\rho}.
+```
+
+A comparison requires a named transformation such as:
+
+```math
+\Phi_*\mu_{\mathrm{triv}}\sim\mu_{\mathrm{nt}}.
+```
+
+Without such a transformation, a claim of "same density" is not admissible.
+
+## 2. Lemmas
+
+### Lemma 1: Trivial zeros are not ordinary negative primes
+
+The trivial zeros of `zeta(s)` occur at negative even integers:
+
+```math
+-2,-4,-6,\ldots
+```
+
+The negatives of the positive primes are:
+
+```math
+-2,-3,-5,-7,-11,\ldots
+```
+
+Therefore:
+
+```math
+\mathcal M^-_{\zeta}\neq\{-p:p\in\mathbb P\}.
+```
+
+The phrase "negative primes" is therefore inadmissible as a literal theorem. It may be retained only as a clearly typed metaphor for a negative mirror-lattice counterpart to positive-prime harmonic structure.
+
+### Lemma 2: Raw density mismatch
+
+The trivial-zero lattice and the non-trivial-zero spectrum do not have the same ordinary counting density.
+
+The trivial-zero counting function has linear growth:
+
+```math
+N_{\mathrm{triv}}(R)\sim\frac{R}{2}.
+```
+
+The non-trivial-zero counting function has asymptotic growth:
+
+```math
+N_{\mathrm{nt}}(T)
+\sim
+\frac{T}{2\pi}\log\frac{T}{2\pi}
+-
+\frac{T}{2\pi}.
+```
+
+Therefore any HPHD claim that the two are density-correspondent requires an explicit embedding, reparameterization, or pushforward measure.
+
+### Lemma 3: Zeta-regularized equality is not ordinary equality
+
+The expression:
+
+```math
+1+1+1+\cdots
+```
+
+diverges as an ordinary series.
+
+The statement:
+
+```math
+1+1+1+\cdots\overset{\zeta\text{-reg}}{=}-\frac12
+```
+
+is a regularized assignment, not a statement of ordinary convergence.
+
+Therefore HPHD must preserve the distinction between:
+
+```math
+=
+```
+
+and:
+
+```math
+\overset{\zeta\text{-reg}}{=}.
+```
+
+### Lemma 4: The mirror lattice is completion-induced
+
+The negative-even vanishing of `zeta(s)` is not a free-standing arithmetic fact about primes. It is induced by the analytic-continuation and functional-equation architecture of the completed zeta system.
+
+Therefore the mirror lattice belongs to the completion layer, not to ordinary prime enumeration.
+
+## 3. Conjectures
+
+### Conjecture 1: Mirror-spectral correspondence
+
+There exists an HPHD embedding, spectral index, or pushforward measure:
+
+```math
+\Phi
+```
+
+such that the regular trivial-zero lattice:
+
+```math
+\mathcal M^-_{\zeta}
+```
+
+and the irregular non-trivial spectrum:
+
+```math
+Z_{\mathrm{nt}}
+```
+
+become comparable as complementary components of a completed harmonic arithmetic system.
+
+This does not mean the two sets are equal. It means the trivial zeros and non-trivial zeros can be interpreted as different projections of a deeper completed structure:
+
+```text
+regular mirror cancellation <-> irregular prime fluctuation
+```
+
+The task for HPHD is to specify the correct embedding measure.
+
+Candidate embedding families:
+
+- logarithmic coordinate transforms;
+- spectral counting maps;
+- operator-theoretic spectra;
+- residue-class harmonic decompositions;
+- Dirichlet-character extensions.
+
+### Conjecture 2: Character-dependent mirror lattices
+
+For each completed Dirichlet L-function `L(s, chi)`, there exists a character-dependent mirror lattice:
+
+```math
+\mathcal M^-_{\chi}
+```
+
+whose structure is determined by the parity, conductor, Gamma factors, and functional equation of `L(s, chi)`.
+
+The zeta mirror lattice:
+
+```math
+\mathcal M^-_{\zeta}=\{-2n:n\in\mathbb N\}
+```
+
+is the base case, not the universal case.
+
+### Conjecture 3: Regularized density shadow principle
+
+Certain divergent positive arithmetic densities admit finite negative regularized invariants after analytic continuation. HPHD interprets these values as density shadows, not ordinary sums.
+
+General form:
+
+```text
+positive divergent accumulation -> analytic continuation -> finite regularized shadow
+```
+
+This principle should be tested against zeta, Dirichlet L-functions, spectral zeta functions, and heat-kernel/zeta regularization analogues.
+
+## 4. Admissible claims
+
+The following claims are admissible:
+
+1. The trivial zeros form a negative mirror lattice of the completed zeta system.
+2. The non-trivial zeros form a fluctuation spectrum tied to prime-distribution irregularity.
+3. Zeta-regularized values are finite analytic shadows of divergent positive densities.
+4. A density correspondence requires an explicit transformation, measure, or embedding.
+5. Dirichlet L-functions likely require character-dependent mirror lattices rather than one universal negative lattice.
+
+## 5. Inadmissible claims without further proof
+
+The following claims are not admissible in literal form:
+
+1. The trivial zeros are primes.
+2. Negative even integers are negative primes.
+3. Trivial zeros and non-trivial zeros have the same density without specifying a measure transformation.
+4. `1+1+1+...=-1/2` as an ordinary summation identity.
+5. HPHD proves RH.
+6. HPHD proves BSD.
+
+## 6. BSD-adjacent relevance boundary
+
+This repository is BSD-adjacent because the same general analytic pattern appears across L-functions:
+
+```text
+arithmetic object -> L-function -> analytic continuation / functional equation -> special values / zeros / rank-like structure
+```
+
+However, this repository does not yet make a BSD theorem claim.
+
+The disciplined route is:
+
+1. Build the base zeta mirror-lattice formalism.
+2. Extend to Dirichlet L-functions.
+3. Extend to modular forms and elliptic-curve L-functions only after the character-dependent case is stable.
+4. Treat order of vanishing, special values, regulators, and rank phenomena as later research lanes.
+
+## 7. Operational guardrail
+
+Every future claim should be classified as one of:
+
+- definition;
+- lemma;
+- conjecture;
+- analogy;
+- computational experiment;
+- theorem proved elsewhere;
+- proposed theorem not yet proved;
+- HPHD-specific interpretation.
+
+No metaphor should be promoted to theorem without a proof object or external mathematical citation.

--- a/lanes/hphd/03-research-roadmap.md
+++ b/lanes/hphd/03-research-roadmap.md
@@ -1,0 +1,243 @@
+# Research Roadmap and Reproducibility Backlog
+
+Status: Draft v0.1  
+Lane: HPHD / zeta mirror-lattice / reproducible analytic-number-theory experiments  
+Purpose: Convert the current HPHD zeta mirror-lattice section into a research program with staged claims, experiments, and BSD-adjacent extensions.
+
+## 1. Operating principle
+
+This repository should advance in three layers:
+
+1. **Manuscript layer** — precise definitions, claim boundaries, and explanatory prose.
+2. **Formal layer** — lemmas, conjectures, admissible transformations, and typed symbolic objects.
+3. **Experimental layer** — reproducible numerical experiments, explicit-formula decompositions, plots, fixtures, and receipts.
+
+The current work lives mostly in layers 1 and 2. The next stage is to build layer 3 without overstating what the experiments prove.
+
+## 2. Immediate backlog
+
+### R1: Define admissible embeddings
+
+Problem: The trivial-zero lattice and non-trivial-zero spectrum have different raw counting densities.
+
+Goal: Define admissible maps:
+
+```math
+\Phi:\mathcal M^-_{\zeta}\to Z_{\mathrm{nt}}
+```
+
+or admissible measure transports:
+
+```math
+\Phi_*\mu_{\mathrm{triv}}\sim\mu_{\mathrm{nt}}.
+```
+
+Acceptance criteria:
+
+- At least three candidate embedding classes are defined.
+- Each candidate states its domain, codomain, measure, and comparison invariant.
+- Each candidate explicitly avoids claiming raw density equality.
+
+Candidate families:
+
+- logarithmic coordinate transforms;
+- zero-counting quantile maps;
+- spectral-index maps;
+- explicit-formula contribution maps;
+- operator-theoretic comparison maps.
+
+### R2: Explicit-formula decomposition experiment
+
+Problem: The manuscript claims that prime counting decomposes into main growth, non-trivial-zero fluctuation, and completion/trivial-zero correction terms.
+
+Goal: Build a reproducible notebook or script that demonstrates a truncated explicit-formula decomposition.
+
+Acceptance criteria:
+
+- Compute a prime-counting or Chebyshev-function target on a bounded range.
+- Compare a smooth main term against a zero-corrected approximation.
+- Track the contribution class of each term.
+- Record numerical error and limitations.
+
+Deliverables:
+
+```text
+experiments/explicit_formula_decomposition.py
+notebooks/explicit_formula_decomposition.ipynb
+receipts/explicit_formula_decomposition_v0.json
+```
+
+### R3: Regularized density examples
+
+Problem: Divergent-series regularization must remain typed as regularization, not ordinary equality.
+
+Goal: Provide minimal reproducible examples for:
+
+```math
+1+1+1+\cdots\overset{\zeta\text{-reg}}{=}-\frac12
+```
+
+and:
+
+```math
+1+2+3+4+\cdots\overset{\zeta\text{-reg}}{=}-\frac1{12}.
+```
+
+Acceptance criteria:
+
+- Ordinary divergence is shown separately.
+- Analytic-continuation value is shown separately.
+- Output labels use `zeta-reg`, not ordinary equality.
+
+### R4: Dirichlet L-function extension
+
+Problem: The zeta mirror lattice is only the base case. HPHD needs character-dependent mirror lattices.
+
+Goal: Extend the framework from `zeta(s)` to `L(s, chi)`.
+
+Acceptance criteria:
+
+- Define primitive Dirichlet characters used in examples.
+- Identify how parity changes completion data and trivial-zero structure.
+- Define `M^-_chi` as a character-dependent mirror lattice.
+- Add at least one worked example for even and odd characters.
+
+Deliverables:
+
+```text
+docs/04-dirichlet-l-mirror-lattices.md
+experiments/dirichlet_l_mirror_lattice.py
+```
+
+### R5: BSD-adjacent bridge map
+
+Problem: The repository is BSD-adjacent but must not pretend to prove BSD.
+
+Goal: Map the analytic pattern from zeta/Dirichlet L-functions toward elliptic-curve L-functions.
+
+Acceptance criteria:
+
+- Explain the shared template:
+
+```text
+arithmetic object -> L-function -> analytic continuation / functional equation -> zeros / special values / arithmetic invariant
+```
+
+- Separate zeta-level facts from elliptic-curve-level facts.
+- Define what would be required before a BSD-lane claim is admissible.
+
+Deliverables:
+
+```text
+docs/05-bsd-adjacent-bridge.md
+```
+
+## 3. Suggested repository structure
+
+```text
+.
+├── README.md
+├── LICENSE
+├── docs/
+│   ├── 01-negative-mirror-lattice.md
+│   ├── 02-formal-claims.md
+│   ├── 03-research-roadmap.md
+│   ├── 04-dirichlet-l-mirror-lattices.md
+│   └── 05-bsd-adjacent-bridge.md
+├── experiments/
+│   ├── explicit_formula_decomposition.py
+│   ├── regularized_density_examples.py
+│   └── dirichlet_l_mirror_lattice.py
+├── notebooks/
+│   └── explicit_formula_decomposition.ipynb
+├── receipts/
+│   └── explicit_formula_decomposition_v0.json
+└── tests/
+    └── test_claim_boundaries.py
+```
+
+## 4. Claim taxonomy for future commits
+
+Every new document should label claims as:
+
+- `Definition`
+- `Lemma`
+- `Conjecture`
+- `Analogy`
+- `External theorem`
+- `Computational experiment`
+- `HPHD interpretation`
+- `Open problem`
+
+This prevents interpretive language from silently hardening into theorem language.
+
+## 5. First experimental design: explicit formula v0
+
+### Objective
+
+Show that a prime-counting target can be approximated by a smooth term plus zero-derived corrections, while preserving the distinction among:
+
+- pole/main-term contribution;
+- non-trivial-zero oscillatory contribution;
+- trivial-zero/completion contribution;
+- truncation error.
+
+### Minimal implementation
+
+Use `mpmath`, `sympy`, or Sage/PARI bindings if available. Prefer open-source and reproducible dependencies.
+
+Initial Python direction:
+
+```text
+Python 3.11+
+mpmath
+sympy
+pytest
+ruff
+```
+
+### Receipt schema sketch
+
+```json
+{
+  "experiment": "explicit_formula_decomposition_v0",
+  "status": "draft",
+  "target_function": "psi(x) or pi(x)",
+  "x_range": [10, 100000],
+  "zero_count": 0,
+  "terms": {
+    "main": "recorded",
+    "non_trivial_zero_correction": "recorded",
+    "trivial_completion_correction": "recorded",
+    "truncation_error": "recorded"
+  },
+  "claim_boundary": "numerical illustration, not proof"
+}
+```
+
+## 6. Quality gates
+
+Before promoting any result:
+
+1. Ordinary equality and regularized equality must be visually distinct.
+2. All density comparisons must name the measure.
+3. Any use of RH must be labeled conditional.
+4. Any BSD mention must be labeled adjacent unless elliptic-curve L-function machinery is actually present.
+5. Every experiment must emit a receipt.
+6. Every plot must state whether it is illustrative, heuristic, or validated.
+
+## 7. Next two implementation steps
+
+1. Add `experiments/regularized_density_examples.py` with explicit divergence-vs-regularization labels.
+2. Add `experiments/explicit_formula_decomposition.py` as a bounded numerical demonstration, initially without claiming theorem-level significance.
+
+## 8. Current completion estimate
+
+- Manuscript capture: 70%
+- Formal claim boundary: 55%
+- Experimental scaffolding: 0%
+- Dirichlet L-function extension: 0%
+- BSD-adjacent bridge: 0%
+- Overall repo lane readiness: 25%
+
+This is enough to preserve the work and prevent loss. It is not yet enough to claim a functioning research harness.

--- a/lanes/hphd/04-explicit-formula-typing-gate.md
+++ b/lanes/hphd/04-explicit-formula-typing-gate.md
@@ -1,0 +1,165 @@
+# Explicit Formula + Typing Gate (HPHD)
+
+Status: Draft v0.1  
+Lane: HPHD / zeta mirror-lattice  
+Purpose: Provide a manuscript-grade *gate* that justifies (i) “background vs oscillations” claims via an explicit formula, and (ii) “negative / regularized density” language via strict typing rules.
+
+---
+
+## 1. Why this file exists
+
+HPHD wants to say:
+
+- Trivial zeros behave like a *rigid negative mirror lattice* (regular cancellation scaffold).
+- Non-trivial zeros behave like a *fluctuation spectrum* (prime irregularity signal).
+- Certain divergent positive densities admit finite *regularized* negative invariants.
+
+This is admissible only if we tether the metaphors to a formula-level decomposition and forbid category errors with a typing system.
+
+---
+
+## 2. Explicit formula bridge (one equation; each term typed)
+
+Define the Chebyshev function
+
+```math
+\psi(x) := \sum_{n\le x} \Lambda(n),
+```
+
+where the von Mangoldt function is
+
+```text
+Λ(n) = log p  if n = p^k
+Λ(n) = 0      otherwise.
+```
+
+A canonical explicit-formula representation (for `x>1`, with the usual midpoint convention at discontinuities) is:
+
+```math
+\psi(x)
+=
+ x
+-\sum_{\rho}\frac{x^{\rho}}{\rho}
+-\log(2\pi)
+-\frac12\log\bigl(1-x^{-2}\bigr).
+```
+
+Interpretation term-by-term:
+
+1) **Main growth** `x`  
+Source: the pole of `ζ(s)` at `s=1` (residue).  
+HPHD role: *smooth baseline*.
+
+2) **Non-trivial zero spectrum** `- Σ_ρ x^ρ/ρ`  
+Source: non-trivial zeros `ρ` of `ζ(s)` in `0<Re(ρ)<1`.  
+HPHD role: *oscillatory fluctuation spectrum* driving prime-counting irregularity.
+
+If RH holds, `ρ = 1/2 + iγ`, so
+
+```math
+x^{\rho}=x^{1/2}\,e^{i\gamma\log x},
+```
+
+which is an oscillation in `log x` with amplitude scale `x^{1/2}`.
+
+3) **Trivial-zero mirror lattice correction** `-(1/2) log(1-x^{-2})`  
+Source: trivial zeros at `-2,-4,-6,...`.  
+HPHD role: *rigid negative mirror-lattice correction (regular, non-mysterious).*
+
+The mirror-lattice structure is exposed by expansion:
+
+```math
+-\frac12\log(1-x^{-2})
+=
+\frac12\sum_{n\ge 1}\frac{x^{-2n}}{n}.
+```
+
+4) **Completion normalization** `-log(2π)`  
+Source: completed zeta normalization; equivalently `ζ'(0)/ζ(0)=\log(2\pi)` so the constant matches the completion layer.  
+HPHD role: *completion constant; not prime signal.*
+
+### Manuscript-safe synthesis
+
+The explicit formula implements:
+
+```text
+prime-power density  = smooth baseline  + (non-trivial oscillations) + (trivial-lattice/completion corrections).
+```
+
+So the “bassline vs prime music” metaphor is permitted only as shorthand for the explicit decomposition above.
+
+---
+
+## 3. Typing rules (so we never lie with “=”)
+
+HPHD uses the following type system.
+
+### Rule T1: Convergent equality vs regularized assignment
+
+If `Σ a_n` diverges, we do not write `Σ a_n = c`. We write a typed assignment:
+
+```math
+\Bigl(\sum_{n\ge1} a_n\Bigr)_{\zeta\text{-reg}} := c.
+```
+
+or the compact notation already used in this repo:
+
+```math
+\sum_{n\ge1} a_n \overset{\zeta\text{-reg}}{=} c.
+```
+
+### Rule T2: Regularization is a functional, not a limit claim
+
+A regularized value does **not** assert partial sums converge. It asserts the regularization functional assigns a value compatible with analytic continuation.
+
+### Rule T3: “Negative” must be typed
+
+Whenever HPHD says “negative,” it must be declared as one of:
+
+- **(Sign)**: algebraic sign inside ordinary arithmetic.
+- **(Dual/renormalized)**: analytic continuation / subtraction of divergences / regularized invariant.
+
+### Rule T4: Density comparisons require an explicit measure layer
+
+Claims like “same density” are inadmissible unless we explicitly name:
+
+- coordinate choice;
+- measure (counting measure, spectral measure, kernel-weighted measure);
+- embedding / pushforward map.
+
+### Rule T5: “Negative primes” is never literal
+
+If the phrase is used, it is an HPHD *operator name* for the mirror-lattice structure and must be defined as such. No statement may assert “trivial zeros are primes.”
+
+### Rule T6: Metaphor gating
+
+Metaphors are permitted only when they can be backed by:
+
+- an explicit formula decomposition; or
+- a clearly declared transform/kernel that yields the intended comparison.
+
+---
+
+## 4. Minimal checklist before promoting an HPHD claim
+
+Every candidate statement must be tagged as one of:
+
+- definition
+- lemma
+- conjecture
+- analogy
+- computational experiment
+- theorem (external citation)
+
+If it is an analogy, it must reference the explicit-formula decomposition or a declared transform/measure.
+
+---
+
+## 5. Immediate follow-ons (research lanes)
+
+1) Pick HPHD’s default embedding/kernel for comparing mirror-lattice measures with non-trivial-zero measures.
+2) Extend the “mirror lattice” notion from `ζ(s)` to Dirichlet `L(s,χ)` where completion/parity alters trivial-zero structure.
+3) Implement explicit-formula experiments that numerically separate:
+   - main term,
+   - non-trivial oscillations,
+   - trivial/completion correction terms.

--- a/lanes/hphd/05-richter-saturation-spec-v0-2.md
+++ b/lanes/hphd/05-richter-saturation-spec-v0-2.md
@@ -1,0 +1,146 @@
+# Richter Saturation SPEC v0.2 Note
+
+Status: **empirical SPEC refinement / finite-window diagnostic / not RH evidence**.  
+Scope: explicit-formula / prime-harness variance-explained diagnostics.  
+Source class: Part A Richter saturation measurement handoff.  
+Claim discipline: finite-window empirical guidance only.
+
+## 0. Purpose
+
+This note records the Richter saturation measurement as a SPEC v0.2 design input. The result validates the need for the `Delta u / N` correction and shows that interval/box resolution controls whether zero-band expansion improves or over-saturates the model.
+
+This is not evidence for RH, GRH, BSD, or any asymptotic theorem. It is an empirical harness-design result.
+
+## 1. Measurement table
+
+| Interval | n_boxes | Peak R^2 | At T | Interpretation |
+|---|---:|---:|---:|---|
+| I1 | 4 | 0.949 | 30 | Over-saturation above T=30 |
+| I1 | 16 | 0.954 | 1000 | Still climbing |
+| I2 | 32 | 0.799 | 300 | Over-saturation above T=300 |
+| I3 | 4 | 0.908 | 1000 | Climbing; bandwidth acceptable |
+| I3 | 32 | 0.206 | 1000 | Bandwidth-starved |
+| I4 | 4 | 0.095 | 1000 | Barely above zero |
+
+## 2. SPEC v0.2 implications
+
+### 2.1 Delta-u correction confirmed
+
+The I1 / 4-box regime peaks at `T = 30` and then over-saturates. This matches the Chebyshev band-edge interpretation: once the zero band exceeds the resolution allowed by the box width, additional zeros self-cancel or add noise.
+
+SPEC v0.2 should therefore keep the primary correction toward smaller `Delta u`, with `Delta u = 0.0025` as the primary target unless a later run falsifies it.
+
+### 2.2 Model-1 floor criterion
+
+`I4` at `T = 1000` has `R^2 = 0.095`. That is structurally underpowered for novelty testing. This is not simply a zero-count problem; it may indicate box-resolution or interval-structure mismatch.
+
+Add the following precondition before any G4 novelty gate:
+
+```text
+if VarExpl(Model 1, N*) < 0.30 on an interval:
+    flag interval as structurally_underpowered
+    exclude interval from G4 novelty gate
+```
+
+This prevents Models 2 and 3 from being interpreted as novel when Model 1 cannot establish a minimally explanatory baseline.
+
+### 2.3 Saturation-envelope diagnostic
+
+The `n_boxes` sensitivity is real. For example:
+
+```text
+I1, 4 boxes:  peaks at T=30
+I1, 16 boxes: still climbing at T=1000
+```
+
+These are different resolution regimes, not noise.
+
+SPEC v0.2 should promote the saturation envelope to a first-class M2a output:
+
+```text
+Env(N) = max_{N' <= N} VarExpl(Model 1, N')
+```
+
+The envelope should be emitted alongside raw variance explained so reviewers can distinguish:
+
+```text
+over-saturated regimes
+still-climbing regimes
+bandwidth-starved regimes
+structurally underpowered regimes
+```
+
+## 3. Required SPEC changes
+
+### G0 provenance check
+
+Add a Model-1 floor test:
+
+```yaml
+model1_floor:
+  metric: VarExpl(Model 1, N*)
+  threshold: 0.30
+  below_threshold_status: structurally_underpowered
+  g4_eligible: false
+```
+
+### M2a output contract
+
+Add saturation-envelope output:
+
+```yaml
+m2a_saturation_envelope:
+  metric: Env(N) = max_{N_prime <= N} VarExpl(Model 1, N_prime)
+  required: true
+  emitted_per_interval: true
+  emitted_per_n_boxes: true
+```
+
+### G4 novelty gate
+
+Before G4 can score novelty for Models 2 or 3, require:
+
+```text
+VarExpl(Model 1, N*) >= 0.30
+```
+
+and require that the saturation envelope has been emitted.
+
+## 4. Failure and exclusion semantics
+
+A structurally underpowered interval is not a failed theorem and not a negative result about zeros. It is a harness exclusion flag.
+
+The correct ledger status is:
+
+```text
+excluded_from_G4_due_to_model1_floor
+```
+
+not:
+
+```text
+model failed
+zeros irrelevant
+claim falsified
+```
+
+## 5. Nonclaims
+
+This note does not claim:
+
+- RH or GRH evidence;
+- an asymptotic residual theorem;
+- that Model 1 captures all explicit-formula structure;
+- that I4 is mathematically unimportant;
+- that higher models are invalid on I4;
+- that the observed finite-window R^2 values generalize without uniformity proof.
+
+It only records SPEC-level consequences of the Richter saturation measurement.
+
+## 6. Follow-on implementation tasks
+
+1. Add `model1_floor` to the provenance schema used by the prime harness.
+2. Emit `Env(N)` as a first-class M2a artifact.
+3. Update G4 so structurally underpowered intervals are excluded from novelty scoring.
+4. Add a replay fixture using the six rows above as expected finite-window behavior.
+5. Add the measurement source record to `SocioProphet/systems-learning-loops` under `kb/sources/`.

--- a/lanes/hphd/PROVENANCE.md
+++ b/lanes/hphd/PROVENANCE.md
@@ -1,0 +1,61 @@
+# Lane Provenance: hphd
+
+## Origin
+
+This lane was absorbed from the standalone repository `SocioProphet/hphd-zeta-mirror-lattice`.
+
+The originating repo had evolved beyond the earlier 7-commit / three-document summary. At absorption time, current `main` was:
+
+```text
+b995d34f664b7dde3e1311294934db0ad27a94a6
+```
+
+and included five current documents under `docs/`.
+
+## What was absorbed
+
+Current source documents from `hphd-zeta-mirror-lattice/docs/`:
+
+- `01-negative-mirror-lattice.md`
+- `02-formal-claims.md`
+- `03-research-roadmap.md`
+- `04-explicit-formula-typing-gate.md`
+- `05-richter-saturation-spec-v0-2.md`
+
+The originating `README.md` was adapted into lane-internal framing at `lanes/hphd/README.md`.
+
+## What was not absorbed
+
+- `pyproject.toml` — superseded by Heller-Winters project metadata.
+- `LICENSE` — superseded by the Heller-Winters license.
+- `experiments/`, `tests/`, and generated `receipts/` — not copied in this Stage A absorption. They remain in the source repo as forensic provenance and may be imported later as runnable HW lane apparatus in a separate PR.
+
+## Citation rewrite
+
+After this PR merges, references to:
+
+```text
+SocioProphet/hphd-zeta-mirror-lattice
+```
+
+should be rewritten to:
+
+```text
+SocioProphet/Heller-Winters-Theorem/lanes/hphd
+```
+
+at the merge commit of this PR or a successor.
+
+## Dependency consolidation
+
+Under Heller-Winters, this lane inherits the repository-level dependency declaration:
+
+```text
+SocioProphet/Heller-Godel @ 988307215ad38ccb16514311222184a1b757752b
+```
+
+No additional dependency is introduced by this absorption.
+
+## Claim boundary
+
+This lane is RH-method material. It is not a proof of RH, GRH, an envelope theorem, a critical-line theorem, BSD, or any asymptotic theorem. The Richter saturation note remains finite-window empirical SPEC guidance only.

--- a/lanes/hphd/README.md
+++ b/lanes/hphd/README.md
@@ -1,0 +1,91 @@
+# HPHD Lane: Zeta Mirror Lattice
+
+Lane status: RH sub-lane of Heller-Winters-Theorem, absorbed from `SocioProphet/hphd-zeta-mirror-lattice` per `PROVENANCE.md`.
+
+Distance tier: RH-method. See `boundary.md`.
+
+HPHD zeta mirror-lattice, explicit-formula experiments, and BSD-adjacent reproducibility archive for the trivial-zero mirror-lattice thesis.
+
+This lane captures the current HPHD working program on:
+
+- trivial zeta zeros as negative mirror-lattice structure;
+- non-trivial zeta zeros as fluctuation spectrum;
+- negative mirror lattices for Dirichlet L-functions;
+- zeta-regularized density;
+- finite-window explicit-formula diagnostics and SPEC gates.
+
+## Current thesis
+
+The trivial zeros of the Riemann zeta function are not conceptually disposable. They are the regular negative-side cancellation lattice of the completed zeta system. The non-trivial zeros form the fluctuation spectrum tied to prime-distribution irregularity. Zeta-regularized negative values are finite analytic shadows of divergent positive density.
+
+The manuscript-safe claim is:
+
+```text
+negative domain = mirror lattice + completion correction + regularized density shadow
+```
+
+For the base zeta function:
+
+```math
+\mathcal M^-_{\zeta}=\{-2n:n\in\mathbb N\}
+```
+
+is the canonical HPHD mirror lattice.
+
+## Claim boundary
+
+See `boundary.md` for the canonical lane-boundary statement cross-referenced to Heller-Godel and Heller-Dirac anti-seed.
+
+We may say:
+
+- The trivial zeros form a negative mirror lattice for the completed zeta system.
+- The non-trivial zeros form a fluctuation spectrum tied to prime irregularity.
+- Zeta regularization assigns finite negative invariants to certain divergent positive densities.
+- A density correspondence between trivial and non-trivial zeros requires an explicit embedding, reparameterization, spectral index, or pushforward measure.
+- Richter saturation data informs finite-window harness design only.
+
+We must not say, literally:
+
+- The trivial zeros are primes.
+- The trivial zeros and non-trivial zeros have the same raw density.
+- Divergent series equal their zeta-regularized values as ordinary sums.
+- Finite-window explicit-formula diagnostics constitute RH/GRH evidence.
+
+Use typed notation such as:
+
+```math
+1+1+1+\cdots \overset{\zeta\text{-reg}}{=} -\frac12
+```
+
+not ordinary equality.
+
+## Lane layout
+
+```text
+lanes/hphd/
+├── PROVENANCE.md                         Absorption record from standalone repo
+├── README.md                             This file
+├── boundary.md                           Lane-specific claim boundary + anti-seed cross-references
+├── 01-negative-mirror-lattice.md         Manuscript-grade synthesis
+├── 02-formal-claims.md                   Definitions, lemmas, conjectures, admissible boundaries
+├── 03-research-roadmap.md                Research lanes and reproducibility backlog
+├── 04-explicit-formula-typing-gate.md    Explicit-formula decomposition + typing gate
+└── 05-richter-saturation-spec-v0-2.md    Finite-window Richter saturation SPEC note
+```
+
+## Immediate research lanes
+
+1. Define the admissible embedding class `Phi` for comparing the trivial-zero mirror lattice with the non-trivial-zero spectrum.
+2. Extend from `zeta(s)` to Dirichlet `L(s, chi)` functions so mirror lattices become character/parity dependent.
+3. Build explicit-formula experiments separating main term, non-trivial-zero oscillation, and trivial-zero / completion correction terms. These experiments must comply with PFK PrimeStatsProtocol if they emit descriptive-grade claims.
+4. Integrate Richter saturation finite-window diagnostics into HW explicit-formula harness design without treating them as RH evidence.
+
+## Status
+
+Draft lane. This lane is a research-program capture, not a proof of RH, GRH, BSD, an envelope theorem, or a critical-line theorem.
+
+## Relationship to HW core
+
+This lane is an RH-method contribution to Heller-Winters-Theorem. Its content is methodology development and explicit-formula infrastructure; it does not advance HW's submission-track theorem statement commitment.
+
+When HW's main theorem statement is committed, this lane may contribute to the explicit-formula decomposition apparatus.

--- a/lanes/hphd/boundary.md
+++ b/lanes/hphd/boundary.md
@@ -1,0 +1,44 @@
+# Lane Boundary: hphd
+
+This lane records the trivial-zero mirror-lattice thesis as an RH research sub-lane of Heller-Winters-Theorem.
+
+## Distance tier
+
+RH-method. The mirror-lattice thesis is methodology development for explicit-formula decomposition. It is not RH-core, which would require commitment to a critical-line or envelope-bound theorem statement.
+
+## Permitted claims
+
+- Trivial zeros form a negative mirror lattice for the completed zeta system: `M^-_zeta = {-2n : n in N}`.
+- Non-trivial zeros form a fluctuation spectrum tied to prime irregularity.
+- Zeta regularization assigns finite negative invariants to certain divergent positive densities.
+- A density correspondence between trivial and non-trivial zeros requires an explicit embedding, reparameterization, spectral index, or pushforward measure.
+- Richter saturation measurements may inform finite-window SPEC design, but only as empirical harness guidance.
+
+## Forbidden claims
+
+- The trivial zeros are primes.
+- Trivial and non-trivial zeros have the same raw density.
+- Divergent series equal their zeta-regularized values as ordinary sums.
+- HPHD proves RH, GRH, BSD, or an asymptotic residual theorem.
+- Finite-window variance-explained diagnostics are evidence for RH or GRH.
+
+## Cross-references to canonical anti-seed
+
+This lane operates under HW's `DEPENDENCIES.md` pin of Heller-Godel @ `988307215ad38ccb16514311222184a1b757752b`.
+
+| Anti-seed | Applies because |
+|---|---|
+| `A-MTH-001` | Universal Bridge does not transfer proofs. Any analogy between mirror-lattice and fluctuation spectrum is method-grade. |
+| `A-MTH-003` | Catalan / mu2 fixture is not Clay progress. Any 2-torsion or parity comparison remains fixture-grade. |
+| `A-PFK-OP-001` | Operator invocation is not evidence. pi(x), Li(x), and explicit-formula computations create artifacts, not theorems. |
+| `A-PFK-PROTOCOL-001` | Null passage is not theorem-grade. Any finite-window explicit-formula experiment remains descriptive-grade unless separately promoted. |
+| `A-PFK-PROTOCOL-002` | Window-shopping prevention. Explicit-formula experiments must predeclare intervals, box counts, and zero-band schedules. |
+| `A-HD-SP-001` | If future Connes-style spectral realization work enters this lane, analog spectral data is not target spectral data without identification. |
+
+## Status
+
+Draft lane. No commitment to RH proof, GRH proof, envelope bound, critical-line bound, or submission-grade theorem.
+
+## Future work
+
+The lane may later import runnable experiments from the original standalone repo into HW under `lanes/hphd/experiments/`, but Stage A absorbs the current manuscript/spec documents only. That keeps the first consolidation PR structurally reviewable.


### PR DESCRIPTION
## Summary

Absorbs `SocioProphet/hphd-zeta-mirror-lattice` into Heller-Winters as `lanes/hphd/`.

This consolidates the HPHD zeta mirror-lattice material as an RH-method lane inside the monograph that owns its target object. No claim-grade promotion and no new mathematical claim.

## Actual-state correction

The source repo was newer than the earlier three-doc summary. Current source commit:

```text
b995d34f664b7dde3e1311294934db0ad27a94a6
```

At absorption time it included five current docs, not three. This PR absorbs all five current docs.

## What lands

| File | Status |
|---|---|
| `lanes/hphd/PROVENANCE.md` | New absorption record |
| `lanes/hphd/README.md` | Lane-internal README adapted from source README |
| `lanes/hphd/boundary.md` | New lane boundary and anti-seed cross-reference |
| `lanes/hphd/01-negative-mirror-lattice.md` | Absorbed source doc |
| `lanes/hphd/02-formal-claims.md` | Absorbed source doc |
| `lanes/hphd/03-research-roadmap.md` | Absorbed source doc |
| `lanes/hphd/04-explicit-formula-typing-gate.md` | Absorbed source doc |
| `lanes/hphd/05-richter-saturation-spec-v0-2.md` | Absorbed source doc |
| `README.md` | Classifies hphd as absorbed lane, not external candidate |

## What is not absorbed

- `pyproject.toml`, `LICENSE` — superseded by HW metadata/license.
- `experiments/`, `tests/`, generated `receipts/` — not copied in Stage A. They remain in the source repo as provenance and may be imported later as runnable lane apparatus.

## Claim boundary

This PR does not:

- prove RH or GRH;
- commit the HW main theorem statement;
- promote any claim grade;
- treat finite-window Richter saturation diagnostics as RH evidence;
- affect Candidate C or HW Issue #28 substantive work.

## Companion PR

After this merges, Stage B updates `SocioProphet/hphd-zeta-mirror-lattice` with an archive/redirect README and `ARCHIVED.md`, then the repo can be manually archived in GitHub settings.