### PR TITLE
docs: add HD v0.2 citation supplement

### DIFF
--- a/docs/scope/hd-v02-supplement.md
+++ b/docs/scope/hd-v02-supplement.md
@@ -1,0 +1,12 @@
+# HD v0.2 Supplement
+
+Pin: `44f40725f916509efb4d4a5a027f45fceec9272c`
+
+Allowed identifiers:
+
+- `HD-SP-001`
+- `HD-SP-002`
+- `HD-SP-003`
+- `HD-MTH-001`
+
+Boundary: method-grade citation only; no theorem promotion and no proof transfer.


### PR DESCRIPTION
## Summary

Adds a minimal Heller-Dirac v0.2 citation supplement for Heller-Winters method-grade spectral references.

The supplement records the final Heller-Dirac v0.2 polish pin and permitted identifiers:

- `HD-SP-001`
- `HD-SP-002`
- `HD-SP-003`
- `HD-MTH-001`

## Claim posture

No dependency-file rewrite, no claim-ledger change, no theorem promotion, no proof transfer.