### PR TITLE
docs: add auxiliary bridge proof-safety controls

### DIFF
--- a/docs/proof-governance/auxiliary-model-policy.md
+++ b/docs/proof-governance/auxiliary-model-policy.md
@@ -1,0 +1,106 @@
+# Auxiliary Model Proof Policy
+
+Status: governance scaffold  
+Scope: Heller-Winters Programme, all lanes  
+Purpose: prevent auxiliary constructions from being promoted into theorem-strength claims without an explicit bridge obligation.
+
+## Rule
+
+An auxiliary model may organize, visualize, filter, or generate candidate structure. It does not transfer theorem status from the model to the classical object unless the required bridge is declared and proved or cited.
+
+In symbols, proving
+
+```text
+X and A -> Y
+```
+
+must not be stated as
+
+```text
+X -> Y
+```
+
+unless the repository also carries a bridge proving
+
+```text
+X -> A
+```
+
+or an equivalence proving
+
+```text
+X <-> A.
+```
+
+Here `X` is the classical source condition, `A` is the auxiliary condition, and `Y` is the target claim.
+
+## Required bridge labels
+
+Every theorem-strength use of an auxiliary object must label the bridge type as one of the following.
+
+| Bridge label | Meaning | Permitted theorem-strength use |
+|---|---|---|
+| `definition` | auxiliary object is only notation for the classical object | yes, after definition is explicit |
+| `source_to_auxiliary` | `X -> A` is proved or cited | yes for conclusions requiring `A` |
+| `auxiliary_to_source` | `A -> X` is proved or cited | no for all-`X` claims unless paired with reverse direction |
+| `equivalence` | `X <-> A` is proved or cited | yes |
+| `conditional` | bridge holds under named hypotheses | only with hypotheses retained |
+| `computational` | finite-window support only | no unconditional theorem promotion |
+| `heuristic` | organizing analogy or candidate generator | no theorem promotion |
+| `unknown` | bridge has not been established | no theorem promotion |
+| `rejected` | attempted bridge is known invalid | no claim support |
+
+## Heller-Winters application
+
+The policy applies to all lanes, including:
+
+- prime/operator candidate filters;
+- residual and envelope diagnostics;
+- zeta mirror-lattice methods;
+- spectral-zeta analogies;
+- geometric, descent, and coherence-objective surrogates;
+- empirical phase-gate and finite-window measurements.
+
+A localization operator, harmonic envelope, oscillator variable, mirror-lattice representation, or residual diagnostic is proof-bearing only to the extent that its bridge status is declared.
+
+## Forbidden promotion pattern
+
+The following pattern is disallowed in theorem-strength prose:
+
+```text
+1. Introduce auxiliary condition A.
+2. Prove X and A imply Y.
+3. Conclude X implies Y.
+```
+
+The valid statement is instead:
+
+```text
+X and A imply Y.
+```
+
+To promote the result, add and prove one of:
+
+```text
+X -> A
+X <-> A
+```
+
+with all hypotheses preserved.
+
+## Review checklist
+
+Before a claim is marked `Proven`, `Lemma`, `Theorem`, or `Corollary`, reviewers must ask:
+
+1. What is the classical source object?
+2. What auxiliary object or condition was introduced?
+3. Is the auxiliary condition still present in the conclusion?
+4. If not, where is the bridge that allowed it to be dropped?
+5. Does the bridge hold for all objects in scope or only for a filtered subsystem?
+6. Are finite-window or asymptotic observations being promoted beyond their status?
+
+## Negative-control source
+
+This policy is motivated by a common false-proof archetype in zeta and prime-distribution work: solving an auxiliary zero-set intersection and then presenting the result as a theorem over the full classical zero set.
+
+The repository should treat such examples as proof-safety fixtures, not as mathematical evidence.

--- a/docs/proof-hazards/asymptotic-ratio-fallacies.md
+++ b/docs/proof-hazards/asymptotic-ratio-fallacies.md
@@ -1,0 +1,111 @@
+# Asymptotic Ratio Fallacies
+
+Status: proof-hazard note  
+Scope: prime/operator, HPHD, residual, empirical, and spectral-zeta lanes
+
+## Core warning
+
+Ratio convergence is not equality of residuals.
+
+The implication
+
+```text
+A_N / B_N -> 1
+```
+
+does not imply
+
+```text
+A_N - B_N = 0.
+```
+
+Under suitable nonzero denominator hypotheses, it usually implies only
+
+```text
+A_N - B_N = o(B_N).
+```
+
+That is an asymptotic relative-smallness statement, not a vanishing theorem.
+
+## False inference pattern
+
+Invalid:
+
+```text
+A_N -> k
+B_N -> k
+|A_N| / |B_N| -> 1
+therefore k = 0
+```
+
+Counterexample:
+
+```text
+A_N = 2 + 1/N
+B_N = 2 + 2/N
+```
+
+Then
+
+```text
+A_N -> 2
+B_N -> 2
+A_N / B_N -> 1
+```
+
+but
+
+```text
+k = 2 != 0.
+```
+
+## Heller-Winters risk surfaces
+
+This hazard is especially relevant when prose discusses:
+
+- prime-counting ratios;
+- local-to-global density normalization;
+- residual amplitude quotients;
+- major/minor arc dominance ratios;
+- empirical phase-gate survival rates;
+- finite-window null comparisons;
+- zeta regularization remainders;
+- quotient-normalized operator scores.
+
+## Required distinction
+
+Use the strongest statement actually justified.
+
+| Observed or proved relation | Permitted conclusion | Forbidden conclusion |
+|---|---|---|
+| `A_N/B_N -> 1` | relative error tends to zero, under hypotheses | `A_N = B_N` |
+| `A_N - B_N -> 0` | absolute error tends to zero | exact equality for finite `N` |
+| `R_N = o(B_N)` | residual is asymptotically smaller than baseline | residual vanishes identically |
+| finite-window ratio near `1` | empirical agreement in tested window | asymptotic theorem |
+| null-model survival | failure to falsify in run scope | proof of structural law |
+
+## Reviewer instruction
+
+If a proof or empirical claim uses a ratio, require the author to state:
+
+1. denominator nonzero conditions;
+2. convergence mode;
+3. whether the claim is pointwise, uniform, averaged, or finite-window;
+4. whether the result is exact equality, absolute asymptotic, relative asymptotic, or empirical observation;
+5. whether any residual term is being set to zero rather than bounded.
+
+## Safe Heller-Winters language
+
+Use:
+
+```text
+The normalized discrepancy is asymptotically small relative to the baseline under the stated hypotheses.
+```
+
+Do not use:
+
+```text
+The residual disappears.
+```
+
+unless the proof establishes exact vanishing or a separately stated zero theorem.

--- a/docs/proof-hazards/auxiliary-intersection-fallacy.md
+++ b/docs/proof-hazards/auxiliary-intersection-fallacy.md
@@ -1,0 +1,108 @@
+# Auxiliary Intersection Fallacy
+
+Status: proof-hazard note  
+Scope: all Heller-Winters Programme lanes
+
+## Definition
+
+The auxiliary intersection fallacy occurs when a passage proves a statement on an intersection
+
+```text
+X ∩ A
+```
+
+but states or implies the statement on the full source class
+
+```text
+X.
+```
+
+Equivalently, it proves
+
+```text
+X and A -> Y
+```
+
+but claims
+
+```text
+X -> Y
+```
+
+without proving
+
+```text
+X -> A.
+```
+
+## Why it matters
+
+The Heller-Winters Programme uses filters, envelopes, residual channels, mirror-lattice encodings, operator constraints, and finite-window empirical gates. These are useful instruments, but they can silently narrow the domain.
+
+A result over a narrowed domain is not wrong. The error is dropping the narrowing premise while preserving theorem-strength language.
+
+## Canonical bad pattern
+
+```text
+Let X be the classical condition.
+Let A be an auxiliary model condition.
+We show that X and A force Y.
+Therefore every X satisfies Y.
+```
+
+This is invalid unless the proof also establishes `X -> A`.
+
+## Correct forms
+
+Conditional form:
+
+```text
+For every object satisfying X and A, Y holds.
+```
+
+Bridge form:
+
+```text
+For every object satisfying X, A holds. Since X and A imply Y, every X satisfies Y.
+```
+
+Equivalence form:
+
+```text
+X and A define the same class. Therefore results over A transfer to X.
+```
+
+## Heller-Winters examples to guard
+
+| Source class `X` | Auxiliary condition `A` | Unsafe promotion |
+|---|---|---|
+| prime events | localization-cell membership | all primes satisfy a claim proved only for selected cells |
+| von Mangoldt signal | residual-envelope condition | exact arithmetic behavior inferred from envelope membership |
+| zeta-zero data | mirror-lattice or oscillator constraint | zero-location claim inferred from an auxiliary zero condition |
+| admissible tuple class | positive singular-series heuristic | existence claim inferred from admissibility alone |
+| empirical phase gate | finite-window survival | asymptotic theorem inferred from finite-window survival |
+
+## Reviewer instruction
+
+When reading a theorem-strength passage, mark every premise. If a premise appears before the proof but disappears from the conclusion, require one of:
+
+1. a bridge lemma;
+2. a cited classical theorem;
+3. a downgrade to conditional/conjectural/heuristic status;
+4. a narrowed conclusion retaining the auxiliary premise.
+
+## Safe verdict language
+
+Use:
+
+```text
+The result holds inside the auxiliary model under the stated bridge assumptions.
+```
+
+Do not use:
+
+```text
+The auxiliary model proves the classical theorem.
+```
+
+unless the bridge has already been discharged.

--- a/fixtures/proof_hazards/auxiliary_zero_fallacy.rh-style.md
+++ b/fixtures/proof_hazards/auxiliary_zero_fallacy.rh-style.md
@@ -1,0 +1,121 @@
+# Negative Control: Auxiliary Zero Fallacy
+
+Status: rejected proof pattern  
+Expected validator disposition: fail or downgrade  
+Hazards:
+
+- auxiliary-intersection-fallacy
+- dropped-premise
+- unproved-bridge
+- zero-set-intersection-promotion
+
+## Bad proof pattern
+
+Let `X(s)` be the classical source condition. Let `A(s)` be an auxiliary condition introduced by a model.
+
+Assume:
+
+```text
+X(s) = 0.
+```
+
+The model gives an identity of the form:
+
+```text
+Aux(s) = K(s) + C(s) X(s).
+```
+
+Therefore, at a classical zero,
+
+```text
+Aux(s) = K(s).
+```
+
+Now set
+
+```text
+Aux(s) = 0
+```
+
+and solve
+
+```text
+K(s) = 0.
+```
+
+Suppose this algebra implies
+
+```text
+Y(s).
+```
+
+The bad proof concludes:
+
+```text
+X(s) = 0 -> Y(s).
+```
+
+## Why this must fail
+
+From
+
+```text
+X(s) = 0
+```
+
+we only obtained
+
+```text
+Aux(s) = K(s).
+```
+
+We did not obtain
+
+```text
+Aux(s) = 0
+```
+
+or
+
+```text
+K(s) = 0.
+```
+
+The valid conclusion is only:
+
+```text
+X(s) = 0 and Aux(s) = 0 -> Y(s).
+```
+
+To promote the result, a separate bridge is required:
+
+```text
+X(s) = 0 -> Aux(s) = 0.
+```
+
+## Minimal counterexample schema
+
+Let
+
+```text
+X = 0
+Aux = 3
+K = 3
+```
+
+Then
+
+```text
+Aux = K
+```
+
+but neither side is zero. Equality is not vanishing.
+
+## Required remediation
+
+A manuscript passage matching this fixture must do one of the following:
+
+1. retain the auxiliary condition in the conclusion;
+2. prove the bridge from the classical source condition to the auxiliary condition;
+3. downgrade the claim to heuristic or conditional status;
+4. remove theorem-strength language.


### PR DESCRIPTION
## Summary

Adds a minimal proof-safety tranche derived from the failed auxiliary-zero RH proof pattern review.

This PR adds:

- `docs/proof-governance/auxiliary-model-policy.md`
- `docs/proof-hazards/auxiliary-intersection-fallacy.md`
- `docs/proof-hazards/asymptotic-ratio-fallacies.md`
- `fixtures/proof_hazards/auxiliary_zero_fallacy.rh-style.md`

## Rationale

The repository already distinguishes the Heller-Winters Programme from a completed theorem and already requires claim discipline. This tranche extends that posture with explicit guardrails for auxiliary models, zero-set/intersection promotion, and ratio-limit overclaiming.

The central forbidden promotion is:

```text
X and A -> Y
```

being stated as:

```text
X -> Y
```

without a bridge proving:

```text
X -> A
```

or an equivalence proving:

```text
X <-> A.
```

## Scope

Documentation and fixture only. No manuscript theorem claims are changed. No executable validators are introduced in this tranche.

## Validation

Diff reviewed by compare against `main`:

- 4 added files
- 446 added lines
- 0 deleted lines

## Follow-up

A later PR can add a lightweight dropped-premise / auxiliary-bridge checker and wire it into the existing governance or claim-ledger validation surface.