### PR TITLE
ci: run P210 character table checker

### DIFF
--- a/.github/workflows/claim-ledger-ci.yml
+++ b/.github/workflows/claim-ledger-ci.yml
@@ -7,6 +7,7 @@ on:
       - 'fixtures/**'
       - 'tests/test_claim_ledger_schema.py'
       - 'scripts/generate_json_schema.py'
+      - 'tools/check_p210_character_table.py'
       - 'requirements-dev.txt'
       - 'Makefile'
       - '.github/workflows/claim-ledger-ci.yml'
@@ -16,6 +17,7 @@ on:
       - 'fixtures/**'
       - 'tests/test_claim_ledger_schema.py'
       - 'scripts/generate_json_schema.py'
+      - 'tools/check_p210_character_table.py'
       - 'requirements-dev.txt'
       - 'Makefile'
       - '.github/workflows/claim-ledger-ci.yml'
@@ -30,3 +32,4 @@ jobs:
           python-version: '3.11'
       - run: pip install -r requirements-dev.txt
       - run: make check-claim-ledger
+      - run: make check-p210-character-table


### PR DESCRIPTION
## Summary

Wires the deterministic `P(7)=210` character-table checker into the existing Claim Ledger Validation workflow.

Changes:

- adds `tools/check_p210_character_table.py` to workflow path triggers;
- runs `make check-p210-character-table` after `make check-claim-ledger`.

## Scope

CI wiring only.

This PR does not alter mathematical artifacts, does not prove RH or GRH, and does not add a new workflow surface.

## Validation

Diff reviewed against main:

- 1 commit ahead
- 0 behind
- 1 modified file: `.github/workflows/claim-ledger-ci.yml`
- 3 additions
- 0 deletions

## Follow-up

If this lane becomes too broad later, split finite-table validation into a dedicated workflow. For now the existing Claim Ledger Validation workflow is the narrowest fit because it already runs Makefile validation under Python.