### PR TITLE
tests: validate zero registry schema fixture

### DIFF
--- a/fixtures/zero-registry/valid/zr-001-exp-ap-diagnostic.json
+++ b/fixtures/zero-registry/valid/zr-001-exp-ap-diagnostic.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "zero-registry.v0.1",
+  "registry_id": "HW-ZERO-AP-EXP-001",
+  "claim_class": "normalization_scaffold",
+  "non_claims": [
+    "Does not prove RH.",
+    "Does not prove GRH.",
+    "Does not locate zeros.",
+    "Does not prove PNT in arithmetic progressions."
+  ],
+  "surfaces": [
+    {
+      "surface_id": "SURF-DIRICHLET-MOD3-SIGN",
+      "surface_type": "completed_dirichlet_l_function",
+      "character_label": "chi_3",
+      "display_modulus": 3,
+      "conductor": 3,
+      "primitive_status": "primitive",
+      "parity": "odd",
+      "completed_function": {
+        "normalization_id": "HW-PRIME-CHARACTER-CONDUCTOR-001",
+        "formula_text": "Lambda(s,chi)=(f/pi)^((s+a)/2) Gamma((s+a)/2) L(s,chi)",
+        "root_number_convention": "epsilon(chi) declared when used",
+        "functional_equation_status": "shape_recorded"
+      },
+      "zero_classes": [
+        {
+          "class_id": "ZERO-CHI3-NONTRIVIAL",
+          "class_type": "nontrivial_zero",
+          "symbol": "rho_chi3",
+          "multiplicity_policy": "carried_explicitly",
+          "location_claim": "critical_strip",
+          "ordering_convention": "symmetric_height_truncation",
+          "residue_formula": "-m_rho X^rho Gamma(rho)"
+        },
+        {
+          "class_id": "ZERO-CHI3-TRIVIAL",
+          "class_type": "trivial_zero",
+          "symbol": "tau_chi3",
+          "multiplicity_policy": "carried_explicitly",
+          "location_claim": "standard_trivial_locations",
+          "ordering_convention": "not_applicable",
+          "residue_formula": "declared by completed-function convention"
+        }
+      ],
+      "assumptions": [
+        {
+          "assumption_id": "ASSUME-STANDARD-FE-CHI3",
+          "assumption_type": "standard_functional_equation",
+          "statement": "Use the standard completed Dirichlet L-function functional equation for the primitive odd character modulo 3 when contour-shift artifacts cite this registry."
+        }
+      ]
+    }
+  ]
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pydantic==2.13.3
 pytest==9.0.2
 PyYAML==6.0.3
+jsonschema==4.25.1

--- a/tests/test_zero_registry_schema.py
+++ b/tests/test_zero_registry_schema.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas" / "zero_registry.schema.json"
+FIXTURE_PATH = (
+    ROOT
+    / "fixtures"
+    / "zero-registry"
+    / "valid"
+    / "zr-001-exp-ap-diagnostic.json"
+)
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_zero_registry_schema_is_valid_draft_2020_12():
+    schema = load_json(SCHEMA_PATH)
+
+    Draft202012Validator.check_schema(schema)
+
+
+def test_valid_zero_registry_fixture_passes_schema_validation():
+    schema = load_json(SCHEMA_PATH)
+    fixture = load_json(FIXTURE_PATH)
+    validator = Draft202012Validator(schema)
+
+    errors = sorted(validator.iter_errors(fixture), key=lambda error: error.path)
+
+    assert errors == []
+    assert fixture["registry_id"] == "HW-ZERO-AP-EXP-001"
+    assert fixture["surfaces"][0]["conductor"] == 3
+    assert fixture["surfaces"][0]["display_modulus"] == 3
+    assert fixture["surfaces"][0]["zero_classes"][0]["location_claim"] == "critical_strip"


### PR DESCRIPTION
## Summary

Adds a minimal zero-registry fixture and schema validation test.

Changes:

- adds `fixtures/zero-registry/valid/zr-001-exp-ap-diagnostic.json`;
- adds `tests/test_zero_registry_schema.py`;
- adds `jsonschema==4.25.1` to `requirements-dev.txt`.

The test checks that:

- `schemas/zero_registry.schema.json` is valid Draft 2020-12 JSON Schema;
- the fixture validates against the schema;
- key bookkeeping fields are present and stable.

## Scope

Validation plumbing only. This does not establish any theorem or zero-location result.

## Validation

Diff reviewed against main:

- 3 commits ahead
- 0 behind
- 3 changed files
- 96 additions
- 0 deletions

## Follow-up

Future work can add invalid fixtures for negative-path schema enforcement.