### PR TITLE
tests: add zero registry negative fixtures

### DIFF
--- a/fixtures/zero-registry/invalid/zr-invalid-location-claim.json
+++ b/fixtures/zero-registry/invalid/zr-invalid-location-claim.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "zero-registry.v0.1",
+  "registry_id": "HW-ZERO-BAD-LOCATION-CLAIM",
+  "claim_class": "normalization_scaffold",
+  "surfaces": [
+    {
+      "surface_id": "SURF-BAD-LOCATION-CLAIM",
+      "surface_type": "completed_dirichlet_l_function",
+      "character_label": "chi_bad_location",
+      "display_modulus": 3,
+      "conductor": 3,
+      "primitive_status": "primitive",
+      "parity": "odd",
+      "completed_function": {
+        "normalization_id": "HW-PRIME-CHARACTER-CONDUCTOR-001",
+        "formula_text": "Lambda(s,chi)=(f/pi)^((s+a)/2) Gamma((s+a)/2) L(s,chi)",
+        "functional_equation_status": "shape_recorded"
+      },
+      "zero_classes": [
+        {
+          "class_id": "ZERO-BAD-LOCATION",
+          "class_type": "nontrivial_zero",
+          "symbol": "rho_bad_location",
+          "multiplicity_policy": "carried_explicitly",
+          "location_claim": "proved_GRH_without_proof"
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/zero-registry/invalid/zr-missing-conductor.json
+++ b/fixtures/zero-registry/invalid/zr-missing-conductor.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "zero-registry.v0.1",
+  "registry_id": "HW-ZERO-BAD-MISSING-CONDUCTOR",
+  "claim_class": "normalization_scaffold",
+  "surfaces": [
+    {
+      "surface_id": "SURF-BAD-MISSING-CONDUCTOR",
+      "surface_type": "completed_dirichlet_l_function",
+      "character_label": "chi_bad",
+      "display_modulus": 30,
+      "primitive_status": "induced",
+      "parity": "odd",
+      "completed_function": {
+        "normalization_id": "HW-PRIME-CHARACTER-CONDUCTOR-001",
+        "formula_text": "Lambda(s,chi)=(f/pi)^((s+a)/2) Gamma((s+a)/2) L(s,chi)",
+        "functional_equation_status": "shape_recorded"
+      },
+      "zero_classes": [
+        {
+          "class_id": "ZERO-BAD-NONTRIVIAL",
+          "class_type": "nontrivial_zero",
+          "symbol": "rho_bad",
+          "multiplicity_policy": "carried_explicitly",
+          "location_claim": "critical_strip"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_zero_registry_schema.py
+++ b/tests/test_zero_registry_schema.py
@@ -13,11 +13,23 @@ FIXTURE_PATH = (
     / "valid"
     / "zr-001-exp-ap-diagnostic.json"
 )
+INVALID_FIXTURE_ROOT = ROOT / "fixtures" / "zero-registry" / "invalid"
 
 
 def load_json(path: Path) -> dict:
     with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
+
+
+def zero_registry_validator() -> Draft202012Validator:
+    schema = load_json(SCHEMA_PATH)
+    return Draft202012Validator(schema)
+
+
+def validation_errors(path: Path):
+    validator = zero_registry_validator()
+    fixture = load_json(path)
+    return sorted(validator.iter_errors(fixture), key=lambda error: list(error.path))
 
 
 def test_zero_registry_schema_is_valid_draft_2020_12():
@@ -27,14 +39,25 @@ def test_zero_registry_schema_is_valid_draft_2020_12():
 
 
 def test_valid_zero_registry_fixture_passes_schema_validation():
-    schema = load_json(SCHEMA_PATH)
     fixture = load_json(FIXTURE_PATH)
-    validator = Draft202012Validator(schema)
-
-    errors = sorted(validator.iter_errors(fixture), key=lambda error: error.path)
+    errors = validation_errors(FIXTURE_PATH)
 
     assert errors == []
     assert fixture["registry_id"] == "HW-ZERO-AP-EXP-001"
     assert fixture["surfaces"][0]["conductor"] == 3
     assert fixture["surfaces"][0]["display_modulus"] == 3
     assert fixture["surfaces"][0]["zero_classes"][0]["location_claim"] == "critical_strip"
+
+
+def test_invalid_zero_registry_missing_conductor_fails():
+    errors = validation_errors(INVALID_FIXTURE_ROOT / "zr-missing-conductor.json")
+
+    assert errors
+    assert any("conductor" in error.message for error in errors)
+
+
+def test_invalid_zero_registry_location_claim_fails():
+    errors = validation_errors(INVALID_FIXTURE_ROOT / "zr-invalid-location-claim.json")
+
+    assert errors
+    assert any("proved_GRH_without_proof" in error.message for error in errors)


### PR DESCRIPTION
## Summary

Adds negative-path fixtures for the zero-registry schema and extends the schema test to assert that invalid registries fail validation.

Changes:

- adds `fixtures/zero-registry/invalid/zr-missing-conductor.json`;
- adds `fixtures/zero-registry/invalid/zr-invalid-location-claim.json`;
- extends `tests/test_zero_registry_schema.py` with failure assertions.

## Scope

Schema validation hardening only.

## Validation

Diff reviewed against main:

- 3 commits ahead
- 0 behind
- 3 changed files
- 86 additions
- 4 deletions

## Follow-up

Future work can add a Makefile target that runs the zero-registry schema tests explicitly.