### PR TITLE
ci: run registry checks

### DIFF
--- a/.github/workflows/claim-ledger-ci.yml
+++ b/.github/workflows/claim-ledger-ci.yml
@@ -6,6 +6,7 @@ on:
       - 'schemas/**'
       - 'fixtures/**'
       - 'tests/test_claim_ledger_schema.py'
+      - 'tests/test_zero_registry_schema.py'
       - 'scripts/generate_json_schema.py'
       - 'tools/check_p210_character_table.py'
       - 'requirements-dev.txt'
@@ -16,6 +17,7 @@ on:
       - 'schemas/**'
       - 'fixtures/**'
       - 'tests/test_claim_ledger_schema.py'
+      - 'tests/test_zero_registry_schema.py'
       - 'scripts/generate_json_schema.py'
       - 'tools/check_p210_character_table.py'
       - 'requirements-dev.txt'
@@ -33,3 +35,4 @@ jobs:
       - run: pip install -r requirements-dev.txt
       - run: make check-claim-ledger
       - run: make check-p210-character-table
+      - run: make check-registry


### PR DESCRIPTION
## Summary

Adds the registry validation target to the existing validation workflow.

Changes:

- adds `tests/test_zero_registry_schema.py` to workflow path triggers;
- runs `make check-registry` after the existing validation steps.

## Scope

CI wiring only.

## Validation

- 1 commit ahead
- 0 behind
- 1 modified workflow file
- 3 additions
- 0 deletions