### PR TITLE
build: add P210 character table check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: glossary-strict glossary-check figure-2-1 glossary-apply validate-claim-ledger generate-json-schema check-claim-ledger check-proof-hazards
+.PHONY: glossary-strict glossary-check figure-2-1 glossary-apply validate-claim-ledger generate-json-schema check-claim-ledger check-proof-hazards check-p210-character-table
 
 ## Run glossary enforcement in strict mode (min 1 outside use per term)
 glossary-strict:
@@ -24,6 +24,10 @@ validate-claim-ledger:
 check-proof-hazards:
 	python3 bin/check_proof_hazard_fixtures.py
 	python3 -m pytest -q tests/test_proof_hazard_fixtures.py
+
+## Validate P(7)=210 finite character-table scaffold
+check-p210-character-table:
+	python3 tools/check_p210_character_table.py
 
 ## Generate portable JSON Schema artifacts from Pydantic models
 generate-json-schema:


### PR DESCRIPTION
## Summary

Adds a Makefile target for the deterministic `P(7)=210` character-table checker.

New target:

```bash
make check-p210-character-table
```

which runs:

```bash
python3 tools/check_p210_character_table.py
```

## Scope

Build/local validation wiring only.

This PR does not alter mathematical artifacts, does not prove RH or GRH, and does not add a CI workflow yet.

## Validation

Diff reviewed against main:

- 1 commit ahead
- 0 behind
- 1 modified file: `Makefile`
- 6 additions
- 2 deletions

## Follow-up

Future work can wire this target into an existing CI lane if we want machine-enforced table consistency on every PR.