### PR TITLE
fixtures: add P210 zero registry fixture

### DIFF
--- a/fixtures/zero-registry/valid/zr-002-p210-character-surface.json
+++ b/fixtures/zero-registry/valid/zr-002-p210-character-surface.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "zero-registry.v0.1",
+  "registry_id": "HW-ZERO-P210-CHARACTER-001",
+  "claim_class": "normalization_scaffold",
+  "non_claims": [
+    "Does not prove RH.",
+    "Does not prove GRH.",
+    "Does not locate zeros.",
+    "Does not prove prime equidistribution.",
+    "Does not collapse display modulus and conductor."
+  ],
+  "surfaces": [
+    {
+      "surface_id": "SURF-P210-CHI-1-1-1",
+      "surface_type": "completed_dirichlet_l_function",
+      "character_label": "chi_{1,1,1} mod 210",
+      "display_modulus": 210,
+      "conductor": 105,
+      "primitive_status": "induced",
+      "parity": "odd",
+      "completed_function": {
+        "normalization_id": "HW-PRIME-CHARACTER-CONDUCTOR-001",
+        "formula_text": "Lambda(s,chi)=(f/pi)^((s+a)/2) Gamma((s+a)/2) L(s,chi)",
+        "root_number_convention": "epsilon(chi) declared when used",
+        "functional_equation_status": "shape_recorded"
+      },
+      "zero_classes": [
+        {
+          "class_id": "ZERO-P210-CHI111-NONTRIVIAL",
+          "class_type": "nontrivial_zero",
+          "symbol": "rho_chi111",
+          "multiplicity_policy": "carried_explicitly",
+          "location_claim": "critical_strip",
+          "ordering_convention": "symmetric_height_truncation",
+          "residue_formula": "-m_rho X^rho Gamma(rho)"
+        },
+        {
+          "class_id": "ZERO-P210-CHI111-TRIVIAL",
+          "class_type": "trivial_zero",
+          "symbol": "tau_chi111",
+          "multiplicity_policy": "carried_explicitly",
+          "location_claim": "standard_trivial_locations",
+          "ordering_convention": "not_applicable",
+          "residue_formula": "declared by completed-function convention"
+        }
+      ],
+      "assumptions": [
+        {
+          "assumption_id": "ASSUME-CONDUCTOR-NORMALIZATION-P210-CHI111",
+          "assumption_type": "standard_functional_equation",
+          "statement": "Use the primitive conductor surface associated with chi_{1,1,1}; display modulus 210 is not treated as the analytic conductor."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_zero_registry_schema.py
+++ b/tests/test_zero_registry_schema.py
@@ -6,13 +6,7 @@ from jsonschema import Draft202012Validator
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = ROOT / "schemas" / "zero_registry.schema.json"
-FIXTURE_PATH = (
-    ROOT
-    / "fixtures"
-    / "zero-registry"
-    / "valid"
-    / "zr-001-exp-ap-diagnostic.json"
-)
+VALID_FIXTURE_ROOT = ROOT / "fixtures" / "zero-registry" / "valid"
 INVALID_FIXTURE_ROOT = ROOT / "fixtures" / "zero-registry" / "invalid"
 
 
@@ -38,15 +32,34 @@ def test_zero_registry_schema_is_valid_draft_2020_12():
     Draft202012Validator.check_schema(schema)
 
 
-def test_valid_zero_registry_fixture_passes_schema_validation():
-    fixture = load_json(FIXTURE_PATH)
-    errors = validation_errors(FIXTURE_PATH)
+def test_all_valid_zero_registry_fixtures_pass_schema_validation():
+    fixture_paths = sorted(VALID_FIXTURE_ROOT.glob("*.json"))
 
-    assert errors == []
+    assert fixture_paths
+
+    for fixture_path in fixture_paths:
+        errors = validation_errors(fixture_path)
+        assert errors == [], fixture_path.name
+
+
+def test_valid_exp_ap_fixture_preserves_expected_bookkeeping():
+    fixture = load_json(VALID_FIXTURE_ROOT / "zr-001-exp-ap-diagnostic.json")
+
     assert fixture["registry_id"] == "HW-ZERO-AP-EXP-001"
     assert fixture["surfaces"][0]["conductor"] == 3
     assert fixture["surfaces"][0]["display_modulus"] == 3
     assert fixture["surfaces"][0]["zero_classes"][0]["location_claim"] == "critical_strip"
+
+
+def test_valid_p210_fixture_preserves_conductor_boundary():
+    fixture = load_json(VALID_FIXTURE_ROOT / "zr-002-p210-character-surface.json")
+    surface = fixture["surfaces"][0]
+
+    assert fixture["registry_id"] == "HW-ZERO-P210-CHARACTER-001"
+    assert surface["display_modulus"] == 210
+    assert surface["conductor"] == 105
+    assert surface["primitive_status"] == "induced"
+    assert surface["conductor"] != surface["display_modulus"]
 
 
 def test_invalid_zero_registry_missing_conductor_fails():


### PR DESCRIPTION
## Summary

Adds a valid P(7)=210 character-surface registry fixture and updates the registry schema test to validate every valid fixture.

Changes:

- adds `fixtures/zero-registry/valid/zr-002-p210-character-surface.json`;
- updates `tests/test_zero_registry_schema.py` to validate all valid fixtures;
- adds a regression assertion that the P210 display modulus and conductor remain distinct.

## Scope

Registry fixture and validation coverage only.

## Validation

- 2 commits ahead
- 0 behind
- 2 changed files
- 80 additions
- 11 deletions