### PR TITLE
tools: add finite character operator diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: glossary-strict glossary-check figure-2-1 glossary-apply validate-claim-ledger generate-json-schema check-claim-ledger check-proof-hazards check-p210-character-table check-registry
+.PHONY: glossary-strict glossary-check figure-2-1 glossary-apply validate-claim-ledger generate-json-schema check-claim-ledger check-proof-hazards check-p210-character-table check-registry check-finite-character-operator
 
 ## Run glossary enforcement in strict mode (min 1 outside use per term)
 glossary-strict:
@@ -32,6 +32,11 @@ check-p210-character-table:
 ## Validate analytic registry schema fixtures
 check-registry:
 	python3 -m pytest -q tests/test_zero_registry_schema.py
+
+## Validate finite character-operator diagnostic
+check-finite-character-operator:
+	python3 tools/check_finite_character_operator.py
+	python3 -m pytest -q tests/test_finite_character_operator.py
 
 ## Generate portable JSON Schema artifacts from Pydantic models
 generate-json-schema:

--- a/docs/prime-operator-lane/finite-character-operator-diagnostic.md
+++ b/docs/prime-operator-lane/finite-character-operator-diagnostic.md
@@ -1,0 +1,348 @@
+# Finite Character Operator Diagnostic
+
+Identifier: `HW-PRIME-FINITE-OPERATOR-001`  
+Status: proposed  
+Claim class: finite spectral diagnostic / Hilbert-Polya analogue boundary  
+Lane: prime/operator lane  
+Depends on: `HW-PRIME-HILBERT-EULER-001`, `HW-PRIME-CHARACTER-P210-001`, `HW-PRIME-AP-EXPLICIT-001`, `HW-ZERO-P210-CHARACTER-001`  
+Non-claim: not RH, not GRH, not PNT, not PNT-AP, not a zero-location theorem, not a Yang-Mills mass-gap claim
+
+## 1. Purpose
+
+`HW-PRIME-HILBERT-EULER-001` records the finite topological accounting layer:
+
+```math
+G_P=(\mathbb Z/P\mathbb Z)^\times,
+\qquad
+\mathcal H_P=\mathbb C[G_P],
+\qquad
+\chi(\mathbb P(\mathcal H_P))=\varphi(P).
+```
+
+This artifact records the next layer: a finite operator diagnostic on
+
+```math
+\mathcal H_{210}=L^2(G_{210}).
+```
+
+The goal is to make the finite Hilbert-Polya-shaped analogy computable without upgrading it to theorem strength.
+
+## 2. Correct symmetry for self-adjoint convolution
+
+Let
+
+```math
+G_P=(\mathbb Z/P\mathbb Z)^\times
+```
+
+and let
+
+```math
+K_P:G_P\to\mathbb C
+```
+
+be a finite kernel. Define the convolution operator
+
+```math
+(T_Pf)(g)=\sum_{h\in G_P}K_P(h)f(gh).
+```
+
+A real-valued kernel is not enough to make `T_P` self-adjoint. The correct condition is
+
+```math
+K_P(h^{-1})=\overline{K_P(h)}.
+```
+
+For real-valued kernels this becomes
+
+```math
+K_P(h^{-1})=K_P(h).
+```
+
+This inversion symmetry is the finite group analogue of requiring the operator, not merely the weights, to respect the Hilbert-space adjoint.
+
+## 3. Character diagonalization
+
+Because `G_P` is finite abelian, its characters diagonalize every convolution operator.
+
+For
+
+```math
+\chi\in\widehat{G_P},
+```
+
+we have
+
+```math
+T_P\chi=\lambda_\chi\chi,
+```
+
+where
+
+```math
+\lambda_\chi=\sum_{h\in G_P}K_P(h)\chi(h).
+```
+
+If
+
+```math
+K_P(h^{-1})=\overline{K_P(h)},
+```
+
+then all eigenvalues are real. For `P=210`, there are `48` characters and therefore `48` character eigenvalues.
+
+## 4. `P(7)=210` CRT character coordinates
+
+For
+
+```math
+P(7)=210,
+```
+
+the unit group decomposes as
+
+```math
+G_{210}\cong C_2\times C_4\times C_6.
+```
+
+The diagnostic uses the following CRT generators:
+
+```text
+alpha = 71   order 2
+beta  = 127  order 4
+gamma = 31   order 6
+```
+
+They are determined by the local generator choices:
+
+```text
+alpha: generator 2 in (Z/3Z)^*
+beta:  generator 2 in (Z/5Z)^*
+gamma: generator 3 in (Z/7Z)^*
+```
+
+The exponent of the group is
+
+```math
+\operatorname{exp}(G_{210})=\operatorname{lcm}(2,4,6)=12.
+```
+
+Therefore all character values lie in
+
+```math
+\mu_{12}.
+```
+
+## 5. Cyclotomic source of one-half
+
+The primitive sixth root of unity is
+
+```math
+\zeta_6=e^{i\pi/3}=\frac12+\frac{i\sqrt3}{2}.
+```
+
+Thus
+
+```math
+\operatorname{Re}(\zeta_6)=\cos(\pi/3)=\frac12.
+```
+
+Since
+
+```math
+\mu_6\subset\mu_{12},
+```
+
+this one-half coordinate appears naturally inside the cyclotomic value field of the `P(7)=210` character system.
+
+This is a finite cyclotomic source of the same real coordinate that appears in the critical-line normalization.
+
+## 6. Involution distinction
+
+The Riemann xi-function satisfies the holomorphic functional equation symmetry
+
+```math
+\xi(s)=\xi(1-s).
+```
+
+The critical line is not the fixed locus of the holomorphic map alone. The critical line is the fixed locus of the anti-holomorphic reflection
+
+```math
+s\mapsto1-\overline{s},
+```
+
+because
+
+```math
+s=1-\overline{s}
+\quad\Longleftrightarrow\quad
+\operatorname{Re}(s)=\frac12.
+```
+
+On the cyclotomic side, complex conjugation sends
+
+```math
+\zeta_6\mapsto\overline{\zeta_6}=\zeta_6^5
+```
+
+and fixes the real coordinate
+
+```math
+\operatorname{Re}(\zeta_6)=\frac12.
+```
+
+The structural analogy is involutive symmetry around a one-half coordinate. It is not a proof of RH.
+
+## 7. Modular elliptic-point convention
+
+The point
+
+```math
+e^{i\pi/3}=\frac12+\frac{i\sqrt3}{2}
+```
+
+and the standard modular-domain boundary representative
+
+```math
+e^{2\pi i/3}=-\frac12+\frac{i\sqrt3}{2}
+```
+
+are boundary-paired order-3 elliptic representatives under modular translation conventions.
+
+The safe claim is only that
+
+```math
+\cos(\pi/3)=\frac12
+```
+
+appears simultaneously as:
+
+1. the real coordinate of a sixth root of unity;
+2. the midpoint of the critical strip;
+3. the fixed real coordinate of the anti-holomorphic critical-line reflection;
+4. the real part of a modular order-3 elliptic boundary representative under a chosen translate.
+
+This is structural resonance, not theorem evidence.
+
+## 8. Prime-residue kernel diagnostic
+
+The executable checker uses cutoff
+
+```text
+B = 500
+```
+
+and raw prime-residue weights
+
+```math
+A_{210}(h)=\sum_{\substack{q\le B \\ q\text{ prime} \\ q\bmod 210=h}}\log q.
+```
+
+It then defines the inversion-symmetric kernel
+
+```math
+K_{210}(h)=\frac12\left(A_{210}(h)+A_{210}(h^{-1})\right).
+```
+
+This gives a self-adjoint finite convolution operator on
+
+```math
+\mathcal H_{210}=L^2(G_{210}).
+```
+
+The cutoff is a diagnostic parameter. This is not a general-purpose high-performance number-theoretic primitive; the CRT/discrete-log table is built by brute force over the `48` residues of `G_210`.
+
+## 9. Computed diagnostic outputs
+
+The checker verifies:
+
+```text
+phi(210) = 48
+exp(G_210) = 12
+alpha = 71, beta = 127, gamma = 31
+48 CRT discrete-log coordinates
+inversion symmetry of K_210
+48 character eigenvalues
+real spectrum to numerical tolerance
+character diagonalization by direct convolution action
+```
+
+For cutoff `B=500`, the spectrum has:
+
+```text
+48 eigenvalues, all real to tolerance
+minimum real eigenvalue negative
+maximum real eigenvalue positive
+not symmetric about 0
+```
+
+The absence of generic symmetry about `0` is intentional. Self-adjointness gives real eigenvalues. Symmetry about `0` would require an additional anti-commuting involution or parity condition that is not present in this diagnostic kernel.
+
+## 10. Selberg analogy boundary
+
+The Selberg trace formula is an established bridge between hyperbolic geometry and spectral data. It relates Laplacian eigenvalues to closed geodesic lengths in a precise analytic setting.
+
+This artifact does not invoke the Selberg trace formula as a proof engine. It builds a finite arithmetic analogue in which a declared finite operator has a character-diagonal spectrum.
+
+The analogy is:
+
+| Selberg / hyperbolic side | Heller-Winters finite side |
+|---|---|
+| Laplacian eigenvalues | character eigenvalues of `T_210` |
+| geodesic-length data | wheel residue / prime-residue kernel data |
+| spectral transform | finite character transform |
+| analytic trace formula | finite convolution diagonalization |
+
+This is diagnostic scaffolding for Hilbert-Polya-style reasoning, not RH evidence.
+
+## 11. Status table
+
+| Statement | Status |
+|---|---|
+| `cosh(it)=cos(t)` | established |
+| `zeta_6=e^{i*pi/3}`, `Re(zeta_6)=1/2` | established |
+| characters of `G_210` take values in `mu_12` | established |
+| `H_210 ~= C^48` | established |
+| `chi(P(H_210))=48` | established |
+| inversion-symmetric finite convolution operators are self-adjoint | established |
+| character basis diagonalizes finite abelian convolution operators | established |
+| this finite operator models the actual Hilbert-Polya operator at theorem grade | conjectural / diagnostic only |
+| this implies RH or GRH | false / forbidden |
+| this implies Yang-Mills mass gap | false / forbidden |
+
+## 12. Non-claims
+
+This artifact explicitly does not claim:
+
+1. RH.
+2. GRH.
+3. PNT.
+4. PNT in arithmetic progressions.
+5. Any zero-location theorem.
+6. That the finite spectrum models the actual Hilbert-Polya operator at theorem grade.
+7. That the spectrum is symmetric about `0`.
+8. That a finite spectral diagnostic proves any spectral-gap theorem.
+9. That display modulus equals conductor.
+10. That the zero-registry schema supplies Yang-Mills spectral data.
+11. A Yang-Mills mass gap.
+12. A continuum Yang-Mills construction.
+
+## 13. Implementation reference
+
+Executable checker:
+
+```text
+tools/check_finite_character_operator.py
+```
+
+Tests:
+
+```text
+tests/test_finite_character_operator.py
+```
+
+Make target:
+
+```text
+make check-finite-character-operator
+```

--- a/tests/test_finite_character_operator.py
+++ b/tests/test_finite_character_operator.py
@@ -1,0 +1,83 @@
+import cmath
+import math
+
+from tools.check_finite_character_operator import (
+    ALPHA,
+    BETA,
+    GAMMA,
+    MODULUS,
+    PRIME_CUTOFF,
+    TOLERANCE,
+    build_dlog_table,
+    character_indices,
+    crt_generators,
+    eigenvalues,
+    group_exponent,
+    inversion_symmetric_kernel,
+    kernel_is_inversion_symmetric,
+    multiplicative_order,
+    phi,
+    spectrum_summary,
+)
+
+
+def test_phi_210():
+    assert phi(210) == 48
+
+
+def test_exp_g_210_from_actual_element_orders():
+    assert group_exponent(210) == 12
+
+
+def test_crt_generators_are_fixed_values():
+    assert crt_generators() == (71, 127, 31)
+    assert (ALPHA, BETA, GAMMA) == (71, 127, 31)
+    assert multiplicative_order(ALPHA) == 2
+    assert multiplicative_order(BETA) == 4
+    assert multiplicative_order(GAMMA) == 6
+
+
+def test_dlog_table_spans_full_group():
+    dlog_table = build_dlog_table()
+
+    assert len(dlog_table) == phi(MODULUS) == 48
+
+
+def test_kernel_inversion_symmetry_holds_for_all_elements():
+    kernel = inversion_symmetric_kernel(PRIME_CUTOFF, MODULUS)
+
+    assert len(kernel) == 48
+    assert kernel_is_inversion_symmetric(kernel)
+    for h, value in kernel.items():
+        assert abs(value - kernel[pow(h, -1, MODULUS)]) <= TOLERANCE
+
+
+def test_all_48_character_eigenvalues_are_real_to_tolerance():
+    dlog_table = build_dlog_table()
+    kernel = inversion_symmetric_kernel(PRIME_CUTOFF, MODULUS)
+    values = eigenvalues(kernel, dlog_table)
+
+    assert len(values) == len(character_indices()) == 48
+    assert all(abs(value.imag) <= TOLERANCE for value in values)
+
+
+def test_cos_pi_over_three_real_part_is_one_half():
+    assert abs(cmath.exp(1j * math.pi / 3).real - 0.5) < 1e-12
+
+
+def test_spectrum_is_not_generically_symmetric_about_zero():
+    dlog_table = build_dlog_table()
+    kernel = inversion_symmetric_kernel(PRIME_CUTOFF, MODULUS)
+    summary = spectrum_summary(eigenvalues(kernel, dlog_table))
+
+    assert summary.eigenvalue_count == 48
+    assert summary.min_real < 0
+    assert summary.max_real > 0
+    assert abs(summary.min_real + summary.max_real) > 1.0
+
+
+def test_display_modulus_210_is_not_conductor():
+    display_modulus = 210
+    conductor_example = 105
+
+    assert display_modulus != conductor_example

--- a/tools/check_finite_character_operator.py
+++ b/tools/check_finite_character_operator.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Finite character-operator diagnostic for P(7)=210.
+
+This is a finite arithmetic diagnostic only. It constructs the unit group
+G_210, its CRT character coordinates, an inversion-symmetric prime-residue
+kernel with cutoff B=500, and the associated convolution operator on C[G_210].
+
+It does not prove RH, GRH, PNT, PNT-AP, zero-location results, or any
+Yang-Mills mass-gap statement.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+from functools import reduce
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
+
+MODULUS = 210
+PRIME_CUTOFF = 500
+TOLERANCE = 1e-9
+
+ALPHA = 71
+BETA = 127
+GAMMA = 31
+
+ExponentTriple = Tuple[int, int, int]
+CharacterIndex = Tuple[int, int, int]
+ComplexVector = Dict[int, complex]
+
+
+@dataclass(frozen=True)
+class SpectrumSummary:
+    eigenvalue_count: int
+    min_real: float
+    max_real: float
+    max_abs_imag: float
+
+
+def phi(n: int) -> int:
+    return sum(1 for k in range(1, n + 1) if math.gcd(k, n) == 1)
+
+
+def reduced_residues(modulus: int = MODULUS) -> List[int]:
+    return [a for a in range(1, modulus) if math.gcd(a, modulus) == 1]
+
+
+def crt_residue(congruences: Sequence[Tuple[int, int]], modulus: int = MODULUS) -> int:
+    for candidate in range(modulus):
+        if all(candidate % m == r % m for m, r in congruences):
+            return candidate
+    raise ValueError(f"no CRT solution modulo {modulus}: {congruences!r}")
+
+
+def crt_generators() -> Tuple[int, int, int]:
+    """Return the fixed CRT generators alpha, beta, gamma for G_210."""
+
+    alpha = crt_residue([(2, 1), (3, 2), (5, 1), (7, 1)])
+    beta = crt_residue([(2, 1), (3, 1), (5, 2), (7, 1)])
+    gamma = crt_residue([(2, 1), (3, 1), (5, 1), (7, 3)])
+    return alpha, beta, gamma
+
+
+def multiplicative_order(a: int, modulus: int = MODULUS) -> int:
+    if math.gcd(a, modulus) != 1:
+        raise ValueError(f"{a} is not a unit modulo {modulus}")
+    value = 1
+    for order in range(1, phi(modulus) + 1):
+        value = (value * a) % modulus
+        if value == 1:
+            return order
+    raise ValueError(f"failed to find order for {a} modulo {modulus}")
+
+
+def group_exponent(modulus: int = MODULUS) -> int:
+    return reduce(math.lcm, (multiplicative_order(a, modulus) for a in reduced_residues(modulus)), 1)
+
+
+def build_dlog_table(
+    alpha: int = ALPHA,
+    beta: int = BETA,
+    gamma: int = GAMMA,
+    modulus: int = MODULUS,
+) -> Dict[int, ExponentTriple]:
+    """Build the CRT discrete-log table for C2 x C4 x C6 coordinates."""
+
+    table: Dict[int, ExponentTriple] = {}
+    for e3 in range(2):
+        for e5 in range(4):
+            for e7 in range(6):
+                value = (pow(alpha, e3, modulus) * pow(beta, e5, modulus) * pow(gamma, e7, modulus)) % modulus
+                if value in table:
+                    raise ValueError(f"duplicate CRT coordinate for residue {value}")
+                table[value] = (e3, e5, e7)
+    residues = set(reduced_residues(modulus))
+    if set(table) != residues:
+        missing = sorted(residues - set(table))
+        extra = sorted(set(table) - residues)
+        raise ValueError(f"CRT generators do not span G_{modulus}; missing={missing}, extra={extra}")
+    return table
+
+
+def character_indices() -> List[CharacterIndex]:
+    return [(j, k, ell) for j in range(2) for k in range(4) for ell in range(6)]
+
+
+def character_value(index: CharacterIndex, residue: int, dlog_table: Mapping[int, ExponentTriple]) -> complex:
+    j, k, ell = index
+    e3, e5, e7 = dlog_table[residue]
+    omega_6 = cmath.exp(2j * math.pi / 6)
+    return ((-1) ** (j * e3)) * ((1j) ** (k * e5)) * (omega_6 ** (ell * e7))
+
+
+def is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n == 2:
+        return True
+    if n % 2 == 0:
+        return False
+    divisor = 3
+    while divisor * divisor <= n:
+        if n % divisor == 0:
+            return False
+        divisor += 2
+    return True
+
+
+def primes_up_to(cutoff: int) -> List[int]:
+    return [n for n in range(2, cutoff + 1) if is_prime(n)]
+
+
+def raw_prime_residue_kernel(cutoff: int = PRIME_CUTOFF, modulus: int = MODULUS) -> Dict[int, float]:
+    """Return A(h)=sum log(q) for primes q<=cutoff with q mod modulus = h."""
+
+    kernel = {h: 0.0 for h in reduced_residues(modulus)}
+    for prime in primes_up_to(cutoff):
+        residue = prime % modulus
+        if math.gcd(residue, modulus) == 1:
+            kernel[residue] += math.log(prime)
+    return kernel
+
+
+def inversion_symmetric_kernel(cutoff: int = PRIME_CUTOFF, modulus: int = MODULUS) -> Dict[int, float]:
+    raw = raw_prime_residue_kernel(cutoff, modulus)
+    return {h: 0.5 * (raw[h] + raw[pow(h, -1, modulus)]) for h in reduced_residues(modulus)}
+
+
+def kernel_is_inversion_symmetric(kernel: Mapping[int, float], modulus: int = MODULUS, tolerance: float = TOLERANCE) -> bool:
+    return all(abs(kernel[h] - kernel[pow(h, -1, modulus)]) <= tolerance for h in kernel)
+
+
+def eigenvalue_for_character(
+    index: CharacterIndex,
+    kernel: Mapping[int, float],
+    dlog_table: Mapping[int, ExponentTriple],
+) -> complex:
+    return sum(kernel[h] * character_value(index, h, dlog_table) for h in kernel)
+
+
+def eigenvalues(
+    kernel: Mapping[int, float],
+    dlog_table: Mapping[int, ExponentTriple],
+) -> List[complex]:
+    return [eigenvalue_for_character(index, kernel, dlog_table) for index in character_indices()]
+
+
+def character_vector(index: CharacterIndex, dlog_table: Mapping[int, ExponentTriple], modulus: int = MODULUS) -> ComplexVector:
+    return {g: character_value(index, g, dlog_table) for g in reduced_residues(modulus)}
+
+
+def convolution_action(vector: Mapping[int, complex], kernel: Mapping[int, float], modulus: int = MODULUS) -> ComplexVector:
+    result: ComplexVector = {}
+    for g in reduced_residues(modulus):
+        result[g] = sum(kernel[h] * vector[(g * h) % modulus] for h in kernel)
+    return result
+
+
+def max_character_eigen_error(
+    kernel: Mapping[int, float],
+    dlog_table: Mapping[int, ExponentTriple],
+    modulus: int = MODULUS,
+) -> float:
+    worst = 0.0
+    for index in character_indices():
+        vector = character_vector(index, dlog_table, modulus)
+        image = convolution_action(vector, kernel, modulus)
+        eigenvalue = eigenvalue_for_character(index, kernel, dlog_table)
+        for g in reduced_residues(modulus):
+            worst = max(worst, abs(image[g] - eigenvalue * vector[g]))
+    return worst
+
+
+def spectrum_summary(values: Iterable[complex]) -> SpectrumSummary:
+    vals = list(values)
+    return SpectrumSummary(
+        eigenvalue_count=len(vals),
+        min_real=min(v.real for v in vals),
+        max_real=max(v.real for v in vals),
+        max_abs_imag=max(abs(v.imag) for v in vals),
+    )
+
+
+def run_checks() -> SpectrumSummary:
+    alpha, beta, gamma = crt_generators()
+    if (alpha, beta, gamma) != (ALPHA, BETA, GAMMA):
+        raise AssertionError((alpha, beta, gamma))
+    if (multiplicative_order(ALPHA), multiplicative_order(BETA), multiplicative_order(GAMMA)) != (2, 4, 6):
+        raise AssertionError("unexpected CRT generator orders")
+    if phi(MODULUS) != 48:
+        raise AssertionError("phi(210) must be 48")
+    if group_exponent(MODULUS) != 12:
+        raise AssertionError("exp(G_210) must be 12")
+
+    dlog_table = build_dlog_table()
+    if len(dlog_table) != 48:
+        raise AssertionError("CRT discrete-log table must span 48 residues")
+
+    kernel = inversion_symmetric_kernel(PRIME_CUTOFF, MODULUS)
+    if not kernel_is_inversion_symmetric(kernel):
+        raise AssertionError("kernel is not inversion-symmetric")
+
+    values = eigenvalues(kernel, dlog_table)
+    summary = spectrum_summary(values)
+    if summary.eigenvalue_count != 48:
+        raise AssertionError("expected 48 character eigenvalues")
+    if summary.max_abs_imag > TOLERANCE:
+        raise AssertionError(f"eigenvalues not real to tolerance: {summary.max_abs_imag}")
+
+    error = max_character_eigen_error(kernel, dlog_table)
+    if error > 1e-8:
+        raise AssertionError(f"character diagonalization error too large: {error}")
+
+    return summary
+
+
+def main() -> None:
+    summary = run_checks()
+    print("finite character operator checks passed")
+    print(f"modulus: {MODULUS}")
+    print(f"prime cutoff: {PRIME_CUTOFF}")
+    print(f"phi(210): {phi(MODULUS)}")
+    print(f"exp(G_210): {group_exponent(MODULUS)}")
+    print(f"CRT generators: alpha={ALPHA}, beta={BETA}, gamma={GAMMA}")
+    print(f"eigenvalue count: {summary.eigenvalue_count}")
+    print(f"min eigenvalue real part: {summary.min_real:.12f}")
+    print(f"max eigenvalue real part: {summary.max_real:.12f}")
+    print(f"max absolute imaginary part: {summary.max_abs_imag:.3e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `HW-PRIME-FINITE-OPERATOR-001`, a finite spectral diagnostic for the P(7)=210 character Hilbert space.

Changes:

- adds `docs/prime-operator-lane/finite-character-operator-diagnostic.md`;
- adds `tools/check_finite_character_operator.py`;
- adds `tests/test_finite_character_operator.py`;
- adds `make check-finite-character-operator`.

## Scope

Finite arithmetic diagnostics only.

This PR does not prove RH, GRH, PNT, PNT-AP, zero location, a Yang-Mills mass gap, a spectral-gap theorem, or that the finite spectrum models the actual Hilbert-Polya operator at theorem grade.

## Validation

- base SHA: `a3d52dc09e78df11ba35a8483b72252f6e0ffbec`
- 4 commits ahead
- 0 behind
- 4 changed files
- 690 additions
- 1 deletion
- CI wiring deferred to follow-up PR