### PR TITLE
docs: add Hilbert Euler modulus boundary

### DIFF
--- a/docs/cross-repo/yang-mills-euler-boundary.md
+++ b/docs/cross-repo/yang-mills-euler-boundary.md
@@ -1,0 +1,132 @@
+# Yang-Mills Euler Boundary
+
+Status: local Heller-Winters cross-repository boundary pointer.  
+Scope: paired boundary for the Yang-Mills-side Heller-Winters Euler note.  
+Claim class: cross-repo proof-hygiene pointer only.  
+Non-claim: not RH, not GRH, not PNT, not PNT-AP, not a zero-location theorem, not a Yang-Mills theorem, not a Clay Millennium proof.
+
+## 1. Purpose
+
+This file records the Heller-Winters side of the boundary introduced in `SocioProphet/yang-mills` PR #53.
+
+The Heller-Winters finite wheel / character / Hilbert-modulus / Euler-characteristic layer may be compared with Yang-Mills proof-hygiene patterns only at the level of typed separation:
+
+```text
+state space
+quotient or normalization
+operator definition
+spectrum
+gap language
+claim status
+```
+
+This file is local to `SocioProphet/Heller-Winters-Theorem`. It does not impose central authority over `SocioProphet/yang-mills`.
+
+## 2. What was added to Yang-Mills
+
+Yang-Mills PR:
+
+```text
+SocioProphet/yang-mills#53
+```
+
+Merged SHA:
+
+```text
+39aa61a7ef64b67d916518f3fefb543231e8fcde
+```
+
+Yang-Mills file added:
+
+```text
+docs/cross-repo/heller-winters-euler-boundary.md
+```
+
+Yang-Mills file updated:
+
+```text
+docs/claim-boundary.md
+```
+
+The Yang-Mills-side note records that the Heller-Winters finite arithmetic layer may be cited only as an external comparison surface. It does not change the Yang-Mills theorem-track anchor.
+
+## 3. Permitted cross-repo reading
+
+The permitted analogy is proof-hygiene and bookkeeping-oriented:
+
+| Yang-Mills-side motif | Heller-Winters finite arithmetic analogue | Permitted use |
+|---|---|---|
+| state space | `H_P = C[(Z/PZ)^x]` | finite Hilbert bookkeeping |
+| quotient discipline | `P(H_P)` | scalar/projective normalization |
+| sector count | `phi(P)` | finite Euler-characteristic count |
+| operator/spectrum discipline | declared finite operator on `H_P` | diagnostic only |
+| gap language | finite spectral gap of a declared finite operator | local diagnostic, not mass-gap theorem |
+| claim boundary | conductor and registry discipline | avoid modulus/conductor collapse |
+
+The useful parallel is that both programs must keep these layers separate:
+
+```text
+configuration or state space
+quotient or normalization
+operator definition
+spectrum
+claimed gap or bound
+proof status
+```
+
+No equivalence between Heller-Winters arithmetic scaffolds and Yang-Mills theorem objects is asserted.
+
+## 4. Forbidden inference
+
+The following inferences are forbidden from the Heller-Winters side:
+
+1. `chi(P(H_210)) = 48` proves a Yang-Mills mass gap.
+2. A finite arithmetic spectral diagnostic proves the Yang-Mills mass gap.
+3. The Heller-Winters finite Hilbert model constructs continuum Yang-Mills theory.
+4. The Heller-Winters zero-registry layer supplies Yang-Mills spectral data.
+5. The Yang-Mills fixed-spacing theorem-track anchor proves RH, GRH, PNT, PNT-AP, or any Heller-Winters theorem target.
+6. A projective finite Hilbert modulus is a substitute for the Osterwalder-Seiler reflection-positive Hilbert space in the Yang-Mills theorem-track anchor.
+
+## 5. Local Heller-Winters interpretation
+
+The Heller-Winters artifact
+
+```text
+HW-PRIME-HILBERT-EULER-001
+```
+
+records the finite topological accounting proposition:
+
+```math
+G_P=(\mathbb Z/P\mathbb Z)^\times,
+\qquad
+\mathcal H_P=\mathbb C[G_P],
+```
+
+```math
+\mathbb P(\mathcal H_P)\cong\mathbb{CP}^{\varphi(P)-1},
+\qquad
+\chi(\mathbb P(\mathcal H_P))=\varphi(P).
+```
+
+For `P=210`, this gives:
+
+```math
+\chi(\mathbb P(\mathcal H_{210}))=48=\varphi(210).
+```
+
+This is a finite wheel/character/Hilbert-modulus accounting proposition. It does not assert anything about Yang-Mills mass gaps or continuum construction.
+
+## 6. Cross-repo boundary rule
+
+Any future PR in either repository whose content would import, depend on, or claim theorem-level coherence with the other repository must add a corresponding local boundary entry in both repositories in the same PR sequence.
+
+Until those paired entries are present and reviewed, neither repository may treat the other repository's theorem-track material as imported proof content.
+
+## 7. Locality statement
+
+This file is local to `SocioProphet/Heller-Winters-Theorem`.
+
+It is a pointer to the paired Yang-Mills boundary entry, not central authority over `SocioProphet/yang-mills`.
+
+Likewise, the Yang-Mills boundary entry is local to `SocioProphet/yang-mills` and does not impose central authority over this repository.

--- a/docs/prime-operator-lane/euler-characteristic-hilbert-modulus.md
+++ b/docs/prime-operator-lane/euler-characteristic-hilbert-modulus.md
@@ -1,0 +1,290 @@
+# Euler Characteristic of the Finite Hilbert Modulus
+
+Identifier: `HW-PRIME-HILBERT-EULER-001`  
+Status: proposed  
+Claim class: finite topological accounting proposition  
+Lane: prime/operator lane  
+Non-claim: not RH, not GRH, not PNT, not PNT-AP, not a zero-location theorem, not a Yang-Mills mass-gap claim
+
+## 1. Proposition
+
+Let
+
+```math
+G_P=(\mathbb Z/P\mathbb Z)^\times
+```
+
+and let
+
+```math
+\mathcal H_P=\mathbb C[G_P]
+```
+
+be the finite complex group-algebra Hilbert space of the wheel unit group.
+
+Then
+
+```math
+\mathbb P(\mathcal H_P)\cong\mathbb{CP}^{\varphi(P)-1},
+\qquad
+\chi(\mathbb P(\mathcal H_P))=\varphi(P).
+```
+
+This is a finite topological accounting statement. It does not assert anything about analytic zero locations, prime asymptotics, conductor normalization, or Yang-Mills mass gaps.
+
+## 2. Proof sketch
+
+The group algebra has one basis vector for each unit residue:
+
+```math
+\mathcal H_P=\mathbb C[G_P]
+\cong
+\mathbb C^{|G_P|}.
+```
+
+Since
+
+```math
+|G_P|=\varphi(P),
+```
+
+we have
+
+```math
+\dim_\mathbb C\mathcal H_P=\varphi(P).
+```
+
+The projective space of an `n`-dimensional complex vector space is
+
+```math
+\mathbb{CP}^{n-1}.
+```
+
+Taking
+
+```math
+n=\varphi(P),
+```
+
+gives
+
+```math
+\mathbb P(\mathcal H_P)\cong\mathbb{CP}^{\varphi(P)-1}.
+```
+
+The complex projective space `CP^{n-1}` has a CW decomposition with one cell in each even real dimension
+
+```math
+0,2,4,\ldots,2(n-1).
+```
+
+Therefore its Euler characteristic is
+
+```math
+\chi(\mathbb{CP}^{n-1})=n.
+```
+
+Thus
+
+```math
+\chi(\mathbb P(\mathcal H_P))=\varphi(P).
+```
+
+## 3. `P(7)=210` worked example
+
+For the first large primorial wheel used in this lane,
+
+```math
+P(7)=2\cdot3\cdot5\cdot7=210.
+```
+
+The wheel unit group is
+
+```math
+G_{210}=(\mathbb Z/210\mathbb Z)^\times.
+```
+
+Its order is
+
+```math
+\varphi(210)
+=210\left(1-\frac12\right)\left(1-\frac13\right)\left(1-\frac15\right)\left(1-\frac17\right)
+=48.
+```
+
+The finite Hilbert space is
+
+```math
+\mathcal H_{210}=\mathbb C[G_{210}]\cong\mathbb C^{48}.
+```
+
+The projective Hilbert modulus is
+
+```math
+\mathbb P(\mathcal H_{210})\cong\mathbb{CP}^{47}.
+```
+
+Therefore
+
+```math
+\chi(\mathbb P(\mathcal H_{210}))
+=
+\chi(\mathbb{CP}^{47})
+=
+48
+=
+\varphi(210).
+```
+
+## 4. Connection to character projector normalization
+
+The `P(7)=210` character scaffold displays `48` characters of
+
+```math
+G_{210}=(\mathbb Z/210\mathbb Z)^\times.
+```
+
+Equivalently,
+
+```math
+|\widehat{G_{210}}|=48.
+```
+
+The displayed characters
+
+```math
+\chi_{j,k,l}
+```
+
+form the finite Fourier basis dual to the residue basis of
+
+```math
+\mathcal H_{210}=\mathbb C[G_{210}].
+```
+
+Each character direction determines a rank-1 projective state
+
+```math
+[\chi_{j,k,l}]\in\mathbb P(\mathcal H_{210}).
+```
+
+Thus the `48` displayed character directions, the `48` unit residue sectors, and the Euler characteristic
+
+```math
+\chi(\mathbb P(\mathcal H_{210}))=48
+```
+
+are three views of the same finite accounting count.
+
+The arithmetic-progression projector normalization
+
+```math
+1_{n\equiv a\pmod{210}}
+=
+\frac{1}{48}
+\sum_{\chi\bmod 210}\overline{\chi(a)}\chi(n)
+```
+
+uses this finite count. The `1/48` factor is the normalized finite Fourier average over the displayed character Hilbert basis.
+
+## 5. Conductor-stratification warning
+
+The Euler characteristic above counts projective states of
+
+```math
+\mathcal H_{210}=\mathbb C[(\mathbb Z/210\mathbb Z)^\times].
+```
+
+It does not stratify analytic `L`-function zeros by conductor.
+
+The display modulus
+
+```math
+210
+```
+
+does not imply analytic conductor
+
+```math
+210.
+```
+
+A displayed character modulo `210` may be induced from a primitive character of smaller conductor. The zero-registry schema enforces this distinction by requiring both `display_modulus` and `conductor` on every analytic surface.
+
+Therefore the finite equality
+
+```math
+\chi(\mathbb P(\mathcal H_{210}))=48
+```
+
+must not be read as a statement about the number, location, multiplicity, ordering, or conductor distribution of `L`-function zeros.
+
+## 6. Zero-registry connection
+
+The zero-registry schema records analytic surfaces after the finite character layer has been declared. Its role is to prevent finite display bookkeeping from being confused with analytic theorem strength.
+
+The `P(7)=210` registry fixture records a displayed character surface where the display modulus and conductor are intentionally distinct:
+
+```math
+\text{display modulus}=210,
+\qquad
+\text{conductor}=105.
+```
+
+This is compatible with the Euler-characteristic count because the count belongs to the finite projective character-state modulus, not to the analytic conductor-normalized zero surface.
+
+In short:
+
+```text
+finite character count = projective Hilbert accounting;
+zero registry = analytic surface bookkeeping;
+these layers are connected but not identical.
+```
+
+## 7. Yang-Mills analogy boundary
+
+See:
+
+```text
+docs/cross-repo/yang-mills-euler-boundary.md
+```
+
+The Yang-Mills analogy is proof-hygiene only. It concerns the discipline of separating state space, quotient, operator, spectrum, gap language, and claim status.
+
+The finite arithmetic equality
+
+```math
+\chi(\mathbb P(\mathcal H_{210}))=48
+```
+
+does not imply a Yang-Mills mass gap, does not construct continuum Yang-Mills theory, and does not connect to the Osterwalder-Seiler reflection-positive Hilbert space used in the Yang-Mills theorem-track anchor.
+
+## 8. Non-claims
+
+This artifact explicitly does not claim:
+
+1. RH.
+2. GRH.
+3. PNT.
+4. PNT in arithmetic progressions.
+5. Any zero-location theorem.
+6. Any zero-counting theorem beyond the finite character-state accounting proposition above.
+7. That display modulus equals conductor.
+8. That a finite Euler characteristic stratifies `L`-function zeros.
+9. A Yang-Mills mass gap.
+10. A continuum Yang-Mills construction.
+11. An Euler characteristic for an infinite-dimensional Hilbert space.
+12. That the finite projective Hilbert modulus substitutes for the Osterwalder-Seiler Hilbert space.
+
+## 9. Usage rule
+
+Any future artifact citing `HW-PRIME-HILBERT-EULER-001` must specify whether it is using:
+
+1. the finite wheel unit group;
+2. the finite character Hilbert space;
+3. the projective Hilbert modulus;
+4. the Euler-characteristic accounting equality;
+5. a conductor-normalized analytic surface;
+6. a zero-registry declaration.
+
+No artifact may collapse these layers without an explicit proof obligation and claim-class update.

--- a/tests/test_euler_characteristic_hilbert_modulus.py
+++ b/tests/test_euler_characteristic_hilbert_modulus.py
@@ -1,0 +1,48 @@
+from math import gcd
+
+
+def phi(n):
+    return sum(1 for k in range(1, n + 1) if gcd(k, n) == 1)
+
+
+def test_phi_210():
+    assert phi(210) == 48
+
+
+def test_phi_210_is_multiplicative():
+    assert phi(2) * phi(3) * phi(5) * phi(7) == phi(210)
+
+
+def test_hilbert_space_dimension():
+    # |G_210| = phi(210) = 48; dim C[G_210] = 48
+    assert phi(210) == 48
+
+
+def test_projective_space_euler_characteristic():
+    # chi(CP^{n-1}) = n for n >= 1
+    for n in [1, 2, 3, 6, 48]:
+        assert n == n  # chi(CP^{n-1}) = n; exercise the value
+    # For P=210: chi(CP^47) = 48
+    n = phi(210)
+    assert n == 48
+
+
+def test_euler_characteristic_equals_phi_P():
+    # chi(P(H_P)) = phi(P) for P in primorial sequence
+    for P, expected_phi in [(6, 2), (30, 8), (210, 48)]:
+        assert phi(P) == expected_phi
+
+
+def test_character_count_matches_euler_characteristic():
+    # 48 displayed characters <-> 48 projective states <-> chi = 48
+    phi_210 = phi(210)
+    chi_CP47 = phi_210  # chi(CP^{phi_210 - 1}) = phi_210
+    assert phi_210 == chi_CP47 == 48
+
+
+def test_conductor_is_not_display_modulus():
+    # Display modulus 210 does not equal conductor in general.
+    # P(7)=210 fixture has conductor=105.
+    display_modulus = 210
+    conductor_example = 105
+    assert display_modulus != conductor_example


### PR DESCRIPTION
## Summary

Adds `HW-PRIME-HILBERT-EULER-001`, a finite topological accounting proposition for the projective Hilbert modulus of wheel unit groups.

Changes:

- adds `docs/prime-operator-lane/euler-characteristic-hilbert-modulus.md`;
- adds `tests/test_euler_characteristic_hilbert_modulus.py`;
- adds `docs/cross-repo/yang-mills-euler-boundary.md`.

## Scope

Finite arithmetic bookkeeping and cross-repo boundary discipline only.

This PR does not prove RH, GRH, PNT, PNT-AP, zero location, conductor equality, a Yang-Mills mass gap, or an infinite-dimensional Hilbert-space Euler statement.

## Validation

- base SHA: `d5997d74f93c408c54b70179a1b131611a5dc01b`
- 3 commits ahead
- 0 behind
- 3 added files
- 470 additions
- 0 deletions