### PR TITLE
tools: add antisymmetric character operator diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: glossary-strict glossary-check figure-2-1 glossary-apply validate-claim-ledger generate-json-schema check-claim-ledger check-proof-hazards check-p210-character-table check-registry check-finite-character-operator
+.PHONY: glossary-strict glossary-check figure-2-1 glossary-apply validate-claim-ledger generate-json-schema check-claim-ledger check-proof-hazards check-p210-character-table check-registry check-finite-character-operator check-antisymmetric-character-operator
 
 ## Run glossary enforcement in strict mode (min 1 outside use per term)
 glossary-strict:
@@ -37,6 +37,11 @@ check-registry:
 check-finite-character-operator:
 	python3 tools/check_finite_character_operator.py
 	python3 -m pytest -q tests/test_finite_character_operator.py
+
+## Validate antisymmetric finite character-operator diagnostic
+check-antisymmetric-character-operator:
+	python3 tools/check_antisymmetric_character_operator.py
+	python3 -m pytest -q tests/test_antisymmetric_character_operator.py
 
 ## Generate portable JSON Schema artifacts from Pydantic models
 generate-json-schema:

--- a/docs/prime-operator-lane/antisymmetric-character-operator-diagnostic.md
+++ b/docs/prime-operator-lane/antisymmetric-character-operator-diagnostic.md
@@ -1,0 +1,238 @@
+# Antisymmetric Character Operator Diagnostic
+
+Identifier: `HW-PRIME-ANTISYM-OPERATOR-001`  
+Status: proposed  
+Claim class: finite spectral diagnostic / antisymmetric transfer-kernel boundary  
+Lane: prime/operator lane  
+Depends on: `HW-PRIME-FINITE-OPERATOR-001`  
+Non-claim: not RH, not GRH, not PNT, not a zero-location theorem, not a Yang-Mills mass-gap claim
+
+## 1. Purpose
+
+This artifact records the antisymmetric decomposition of the `P(7)=210` prime-residue kernel used by the finite character-operator diagnostic.
+
+The prior finite operator artifact defined the inversion-symmetric kernel
+
+```math
+K^{+}(h)=\frac12\left(A(h)+A(h^{-1})\right)
+```
+
+and checked the corresponding self-adjoint convolution diagnostic.
+
+This artifact defines the antisymmetric companion
+
+```math
+K^{-}(h)=\frac12\left(A(h)-A(h^{-1})\right).
+```
+
+The split separates time-symmetric and time-antisymmetric arithmetic contributions in the finite residue model.
+
+## 2. Kernel decomposition
+
+Let
+
+```math
+G_{210}=(\mathbb Z/210\mathbb Z)^\times.
+```
+
+For cutoff `B=500`, define the raw prime-residue kernel
+
+```math
+A(h)=\sum_{\substack{q\le B \\ q\text{ prime} \\ q\bmod 210=h}}\log q.
+```
+
+Then
+
+```math
+A(h)=K^{+}(h)+K^{-}(h),
+```
+
+where
+
+```math
+K^{+}(h)=\frac12\left(A(h)+A(h^{-1})\right),
+\qquad
+K^{-}(h)=\frac12\left(A(h)-A(h^{-1})\right).
+```
+
+The two components satisfy
+
+```math
+K^{+}(h^{-1})=K^{+}(h),
+\qquad
+K^{-}(h^{-1})=-K^{-}(h).
+```
+
+Equivalently,
+
+```math
+K^{+}(h)+K^{-}(h)=A(h),
+\qquad
+K^{+}(h)-K^{-}(h)=A(h^{-1}).
+```
+
+## 3. Self-adjointness and skew-adjointness
+
+`HW-PRIME-FINITE-OPERATOR-001` established the symmetric condition:
+
+```math
+K^{+}(h^{-1})=K^{+}(h).
+```
+
+The convolution operator by `K^+` is self-adjoint and has real eigenvalues.
+
+For the antisymmetric component,
+
+```math
+K^{-}(h^{-1})=-K^{-}(h).
+```
+
+The raw convolution operator
+
+```math
+(C_{K^-}f)(g)=\sum_{h\in G_{210}}K^{-}(h)f(gh)
+```
+
+is skew-Hermitian. Therefore its raw eigenvalues are purely imaginary, up to numerical tolerance.
+
+The self-adjoint antisymmetric diagnostic is
+
+```math
+T^{-}=-i C_{K^-}.
+```
+
+This is the operator whose spectrum is checked as real and symmetric about zero.
+
+This distinction is mandatory: a real inversion-antisymmetric kernel does not itself produce a self-adjoint convolution operator. The factor `-i` converts the skew-Hermitian generator into a self-adjoint finite diagnostic.
+
+## 4. Why the spectrum is symmetric
+
+For a character
+
+```math
+\chi\in\widehat{G_{210}},
+```
+
+the raw antisymmetric convolution eigenvalue is
+
+```math
+\mu_\chi=\sum_{h\in G_{210}}K^{-}(h)\chi(h).
+```
+
+Because
+
+```math
+K^{-}(h^{-1})=-K^{-}(h)
+```
+
+and
+
+```math
+\overline{\chi(h)}=\chi(h^{-1}),
+```
+
+the conjugate character satisfies
+
+```math
+\mu_{\overline{\chi}}=-\mu_\chi.
+```
+
+For the self-adjoint diagnostic
+
+```math
+\lambda_\chi=-i\mu_\chi,
+```
+
+the corresponding eigenvalues satisfy
+
+```math
+\lambda_{\overline{\chi}}=-\lambda_\chi.
+```
+
+Thus the checked finite diagnostic spectrum is symmetric about zero.
+
+## 5. Transfer-matrix analogy boundary
+
+The decomposition
+
+```math
+A=K^{+}+K^{-}
+```
+
+has the following finite diagnostic interpretation:
+
+| Component | Finite arithmetic role | Analogy boundary |
+|---|---|---|
+| `K^+` | inversion/time-symmetric kernel | symmetric part of a transfer matrix |
+| `K^-` | inversion/time-antisymmetric kernel | antisymmetric contribution / CP-violating-type diagnostic |
+| `-i C_{K^-}` | self-adjoint antisymmetric generator | finite spectral diagnostic only |
+
+Keeping `K^+` and `K^-` separate mirrors the discipline of separating time-reflection-even and time-reflection-odd contributions in Osterwalder-Seiler-style reasoning.
+
+This is only an analogy about decomposition discipline. It does not import Yang-Mills theorem strength and does not identify the finite arithmetic Hilbert space with the Osterwalder-Seiler Hilbert space.
+
+## 6. Operational substrate
+
+Executable checker:
+
+```text
+tools/check_antisymmetric_character_operator.py
+```
+
+Tests:
+
+```text
+tests/test_antisymmetric_character_operator.py
+```
+
+Make target:
+
+```text
+make check-antisymmetric-character-operator
+```
+
+The checker imports from `tools/check_finite_character_operator.py` and reuses the existing finite arithmetic substrate:
+
+```text
+raw_prime_residue_kernel
+reduced_residues
+build_dlog_table
+character_indices
+eigenvalue_for_character
+inversion_symmetric_kernel
+spectrum_summary
+```
+
+It does not duplicate the finite character-table or residue-kernel machinery.
+
+## 7. Verified finite diagnostics
+
+For `P=210` and cutoff `B=500`, the checker verifies:
+
+```text
+K^-(h) + K^-(h^-1) = 0
+K^-(h) = 0 for self-inverse residues h^2 = 1 mod 210
+48 character eigenvalues
+raw antisymmetric convolution spectrum is imaginary
+-i times raw antisymmetric convolution has real spectrum
+self-adjoint antisymmetric spectrum is symmetric about 0
+K^+ + K^- = A
+K^+ - K^- = A(h^-1)
+```
+
+## 8. Non-claims
+
+This artifact explicitly does not claim:
+
+1. RH.
+2. GRH.
+3. PNT.
+4. PNT in arithmetic progressions.
+5. Any zero-location theorem.
+6. That finite spectral symmetry implies RH.
+7. That this finite operator models the actual Hilbert-Polya operator at theorem grade.
+8. A Yang-Mills mass gap.
+9. A continuum Yang-Mills construction.
+10. That the finite arithmetic Hilbert space is the Osterwalder-Seiler Hilbert space.
+11. That display modulus `210` equals analytic conductor.
+12. That the antisymmetric spectrum supplies zero-registry zero locations.

--- a/tests/test_antisymmetric_character_operator.py
+++ b/tests/test_antisymmetric_character_operator.py
@@ -1,0 +1,72 @@
+from tools.check_antisymmetric_character_operator import (
+    MODULUS,
+    PRIME_CUTOFF,
+    antisymmetric_kernel,
+    kernel_is_antisymmetric,
+    self_adjoint_antisymmetric_eigenvalues,
+    spectrum_is_symmetric_about_zero,
+)
+from tools.check_finite_character_operator import (
+    TOLERANCE,
+    build_dlog_table,
+    inversion_symmetric_kernel,
+    raw_prime_residue_kernel,
+    reduced_residues,
+    spectrum_summary,
+)
+
+
+def test_antisymmetric_kernel_satisfies_inversion_condition():
+    kernel = antisymmetric_kernel(PRIME_CUTOFF, MODULUS)
+
+    assert kernel_is_antisymmetric(kernel, MODULUS, TOLERANCE)
+    for h in reduced_residues(MODULUS):
+        assert abs(kernel[h] + kernel[pow(h, -1, MODULUS)]) <= TOLERANCE
+
+
+def test_antisymmetric_kernel_is_pure_imaginary_on_diagonal_elements():
+    kernel = antisymmetric_kernel(PRIME_CUTOFF, MODULUS)
+
+    self_inverse_elements = [
+        h for h in reduced_residues(MODULUS) if (h * h) % MODULUS == 1
+    ]
+    assert self_inverse_elements
+
+    for h in self_inverse_elements:
+        assert abs(kernel[h]) <= TOLERANCE
+
+
+def test_all_48_antisymmetric_eigenvalues_are_real():
+    dlog_table = build_dlog_table()
+    kernel = antisymmetric_kernel(PRIME_CUTOFF, MODULUS)
+    values = self_adjoint_antisymmetric_eigenvalues(kernel, dlog_table)
+
+    assert len(values) == 48
+    assert all(abs(value.imag) < 1e-8 for value in values)
+
+
+def test_antisymmetric_spectrum_is_symmetric_about_zero():
+    dlog_table = build_dlog_table()
+    kernel = antisymmetric_kernel(PRIME_CUTOFF, MODULUS)
+    values = self_adjoint_antisymmetric_eigenvalues(kernel, dlog_table)
+
+    assert spectrum_is_symmetric_about_zero(values, tolerance=1e-6)
+    summary = spectrum_summary(values)
+    assert summary.min_real < 0
+    assert summary.max_real > 0
+    assert abs(summary.min_real + summary.max_real) < 1e-6
+
+
+def test_antisymmetric_and_symmetric_kernels_are_orthogonal_decomposition():
+    raw = raw_prime_residue_kernel(PRIME_CUTOFF, MODULUS)
+    symmetric = inversion_symmetric_kernel(PRIME_CUTOFF, MODULUS)
+    antisymmetric = antisymmetric_kernel(PRIME_CUTOFF, MODULUS)
+
+    for h in reduced_residues(MODULUS):
+        inverse = pow(h, -1, MODULUS)
+        assert abs(symmetric[h] + antisymmetric[h] - raw[h]) <= TOLERANCE
+        assert abs(symmetric[h] - antisymmetric[h] - raw[inverse]) <= TOLERANCE
+
+
+def test_display_modulus_210_is_not_conductor():
+    assert 210 != 105

--- a/tools/check_antisymmetric_character_operator.py
+++ b/tools/check_antisymmetric_character_operator.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Antisymmetric finite character-operator diagnostic for P(7)=210.
+
+Computes K^-(h) = (A(h) - A(h^{-1})) / 2 — the antisymmetric prime-residue
+kernel. The raw convolution by K^- is skew-Hermitian; the diagnostic
+self-adjoint operator is -i times that convolution and has real spectrum
+symmetric about 0.
+
+This is a finite arithmetic diagnostic only. Does not prove RH, GRH, PNT,
+zero-location, or Yang-Mills mass gap.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.check_finite_character_operator import (
+    MODULUS,
+    PRIME_CUTOFF,
+    TOLERANCE,
+    build_dlog_table,
+    character_indices,
+    eigenvalue_for_character,
+    inversion_symmetric_kernel,
+    raw_prime_residue_kernel,
+    reduced_residues,
+    spectrum_summary,
+)
+
+
+def antisymmetric_kernel(cutoff: int = PRIME_CUTOFF, modulus: int = MODULUS) -> Dict[int, float]:
+    """Return K^-(h)=(A(h)-A(h^-1))/2 for the prime-residue kernel A."""
+
+    raw = raw_prime_residue_kernel(cutoff, modulus)
+    return {h: 0.5 * (raw[h] - raw[pow(h, -1, modulus)]) for h in reduced_residues(modulus)}
+
+
+def kernel_is_antisymmetric(
+    kernel: Mapping[int, float],
+    modulus: int = MODULUS,
+    tol: float = TOLERANCE,
+) -> bool:
+    """Check K(h)+K(h^-1)=0 on every unit residue."""
+
+    return all(abs(kernel[h] + kernel[pow(h, -1, modulus)]) <= tol for h in kernel)
+
+
+def raw_antisymmetric_eigenvalue(index, kernel, dlog_table) -> complex:
+    """Eigenvalue of raw convolution by K^-; skew-Hermitian, hence imaginary."""
+
+    return eigenvalue_for_character(index, kernel, dlog_table)
+
+
+def self_adjoint_antisymmetric_eigenvalue(index, kernel, dlog_table) -> complex:
+    """Eigenvalue of -i times raw antisymmetric convolution; real diagnostic."""
+
+    return -1j * raw_antisymmetric_eigenvalue(index, kernel, dlog_table)
+
+
+def self_adjoint_antisymmetric_eigenvalues(
+    kernel: Mapping[int, float],
+    dlog_table,
+) -> list[complex]:
+    return [
+        self_adjoint_antisymmetric_eigenvalue(index, kernel, dlog_table)
+        for index in character_indices()
+    ]
+
+
+def spectrum_is_symmetric_about_zero(values: Iterable[complex], tolerance: float = 1e-6) -> bool:
+    vals = list(values)
+    remaining = vals.copy()
+    for value in vals:
+        match_index = None
+        for idx, candidate in enumerate(remaining):
+            if abs(candidate + value) <= tolerance:
+                match_index = idx
+                break
+        if match_index is None:
+            return False
+        remaining.pop(match_index)
+    return True
+
+
+def run_checks():
+    dlog_table = build_dlog_table()
+    kernel = antisymmetric_kernel(PRIME_CUTOFF, MODULUS)
+
+    if not kernel_is_antisymmetric(kernel, MODULUS, TOLERANCE):
+        raise AssertionError("kernel is not inversion-antisymmetric")
+
+    raw_values = [
+        raw_antisymmetric_eigenvalue(index, kernel, dlog_table)
+        for index in character_indices()
+    ]
+    if len(raw_values) != 48:
+        raise AssertionError("expected 48 raw antisymmetric eigenvalues")
+    if max(abs(value.real) for value in raw_values) > 1e-8:
+        raise AssertionError("raw antisymmetric convolution spectrum is not imaginary")
+
+    values = self_adjoint_antisymmetric_eigenvalues(kernel, dlog_table)
+    summary = spectrum_summary(values)
+
+    if summary.eigenvalue_count != 48:
+        raise AssertionError("expected 48 self-adjoint antisymmetric eigenvalues")
+    if summary.max_abs_imag > 1e-8:
+        raise AssertionError(f"self-adjoint diagnostic eigenvalues not real: {summary.max_abs_imag}")
+    if not spectrum_is_symmetric_about_zero(values, tolerance=1e-6):
+        raise AssertionError("self-adjoint antisymmetric spectrum is not symmetric about 0")
+
+    return summary
+
+
+def main() -> None:
+    summary = run_checks()
+    print("antisymmetric finite character operator checks passed")
+    print(f"modulus: {MODULUS}")
+    print(f"prime cutoff: {PRIME_CUTOFF}")
+    print("kernel condition: K^-(h) + K^-(h^-1) = 0")
+    print("diagnostic operator: -i times raw antisymmetric convolution")
+    print(f"eigenvalue count: {summary.eigenvalue_count}")
+    print(f"min eigenvalue real part: {summary.min_real:.12f}")
+    print(f"max eigenvalue real part: {summary.max_real:.12f}")
+    print(f"max absolute imaginary part: {summary.max_abs_imag:.3e}")
+    print("symmetric-spectrum confirmation: passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `HW-PRIME-ANTISYM-OPERATOR-001`, an antisymmetric finite character-operator diagnostic for the P(7)=210 prime-residue kernel.

Changes:

- adds `tools/check_antisymmetric_character_operator.py`;
- adds `tests/test_antisymmetric_character_operator.py`;
- adds `docs/prime-operator-lane/antisymmetric-character-operator-diagnostic.md`;
- adds `make check-antisymmetric-character-operator`.

## Mathematical correction recorded

The raw convolution by real `K^-(h)=-K^-(h^-1)` is skew-Hermitian and has imaginary eigenvalues. The checked self-adjoint antisymmetric diagnostic is `-i` times the raw antisymmetric convolution, with real spectrum symmetric about zero.

## Local validation

- `python3 tools/check_antisymmetric_character_operator.py` exits 0.
- `python3 -m pytest tests/test_antisymmetric_character_operator.py -v` reports 6 passed.

## Scope

No CI wiring in this PR. No new dependencies. No RH, GRH, PNT, zero-location, Hilbert-Polya theorem-grade, conductor-equality, or Yang-Mills mass-gap claim.