### PR TITLE
tools: add Gaussian integer operator diagnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: glossary-strict glossary-check figure-2-1 glossary-apply validate-claim-ledger generate-json-schema check-claim-ledger check-proof-hazards check-p210-character-table check-registry check-finite-character-operator check-antisymmetric-character-operator
+.PHONY: glossary-strict glossary-check figure-2-1 glossary-apply validate-claim-ledger generate-json-schema check-claim-ledger check-proof-hazards check-p210-character-table check-registry check-finite-character-operator check-antisymmetric-character-operator check-gaussian-integer-operator
 
 ## Run glossary enforcement in strict mode (min 1 outside use per term)
 glossary-strict:
@@ -42,6 +42,11 @@ check-finite-character-operator:
 check-antisymmetric-character-operator:
 	python3 tools/check_antisymmetric_character_operator.py
 	python3 -m pytest -q tests/test_antisymmetric_character_operator.py
+
+## Validate Gaussian-integer finite character-operator diagnostic
+check-gaussian-integer-operator:
+	python3 tools/check_gaussian_integer_operator.py
+	python3 -m pytest -q tests/test_gaussian_integer_operator.py
 
 ## Generate portable JSON Schema artifacts from Pydantic models
 generate-json-schema:

--- a/docs/prime-operator-lane/gaussian-integer-operator-diagnostic.md
+++ b/docs/prime-operator-lane/gaussian-integer-operator-diagnostic.md
@@ -206,6 +206,26 @@ The character value itself remains a root of unity and therefore has unit norm:
 
 The unit-norm fact and the `SU(2)` Casimir value are not the same statement.
 
+The Pythagorean identity
+
+```math
+\left(\frac{\sqrt3}{2}\right)^2+\left(-\frac12\right)^2=1
+```
+
+expresses the unit-circle constraint on character values. Its components are
+
+```math
+\frac34=j(j+1)\quad (j=1/2)
+```
+
+in the Casimir-compatible normalization above, and
+
+```math
+\frac14=\rho_2
+```
+
+as the Catalan singularity. The `p=3` Puiseux coefficient `sqrt(3)/2` and the `j=1/2` quantum number `1/2` are the real and imaginary components of `varphi_{1,1,1}(g_*)` — orthogonal components of a single unit-circle element. Their sum of squares is `1`. This is the finite arithmetic witness that the Heller-Godel and Heller-Winters programs are not independent in this diagnostic layer: they are complementary projections of the same object onto the real and imaginary subspaces of `Q(zeta_12)`.
+
 ## 5. Gaussian eigenvalue of the distinguished character
 
 The finite Gaussian eigenvalue of the distinguished character is

--- a/docs/prime-operator-lane/gaussian-integer-operator-diagnostic.md
+++ b/docs/prime-operator-lane/gaussian-integer-operator-diagnostic.md
@@ -1,0 +1,282 @@
+# Gaussian Integer Character Operator Diagnostic
+
+Identifier: `HW-PRIME-GAUSSIAN-INT-001`  
+Status: proposed  
+Claim class: finite Gaussian-integer spectral diagnostic / cyclotomic-spin boundary  
+Lane: prime/operator lane  
+Depends on: `HW-PRIME-FINITE-OPERATOR-001`, `HW-PRIME-ANTISYM-OPERATOR-001`  
+Non-claim: not RH, not GRH, not PNT, not a zero-location theorem, not a Yang-Mills mass-gap claim
+
+## 1. Purpose
+
+This artifact records a finite Gaussian-integer operator diagnostic on the `P(7)=210` character Hilbert space.
+
+The diagnostic lifts rational primes that split in `Z[i]`:
+
+```math
+q=a^2+b^2
+```
+
+into unit Gaussian phases
+
+```math
+u_q=\frac{a+ib}{\sqrt q},
+```
+
+aggregates those phases by residue class modulo `210`, and evaluates the finite character transform over
+
+```math
+G_{210}=(\mathbb Z/210\mathbb Z)^\times.
+```
+
+This is a finite arithmetic structural diagnostic. It is not an analytic proof engine.
+
+## 2. Gaussian prime-residue kernel
+
+For cutoff `B=500`, define
+
+```math
+A_{\mathbb Z[i]}(h)
+=
+\sum_{\substack{q\le B \\ q\text{ prime} \\ q\bmod 210=h \\ q=a^2+b^2}}
+\log(q)\frac{a+ib}{\sqrt q}.
+```
+
+Only split rational primes are included: `q=2` and primes `q=1 mod 4`. Rational primes `q=3 mod 4` are inert in `Z[i]` and are omitted from this finite Gaussian diagnostic.
+
+The corresponding character eigenvalue for
+
+```math
+\chi\in\widehat{G_{210}}
+```
+
+is
+
+```math
+\lambda^{\mathbb Z[i]}_\chi
+=
+\sum_{h\in G_{210}}A_{\mathbb Z[i]}(h)\chi(h).
+```
+
+## 3. Character-table substrate
+
+The diagnostic reuses the `P(7)=210` character table from the finite operator package.
+
+The CRT generators are:
+
+```text
+alpha = 71   order 2
+beta  = 127  order 4
+gamma = 31   order 6
+```
+
+The group decomposes as
+
+```math
+G_{210}\cong C_2\times C_4\times C_6,
+```
+
+so all character values lie in
+
+```math
+\mu_{12}.
+```
+
+The distinguished character index is
+
+```math
+\varphi_{1,1,1}.
+```
+
+It is evaluated at the combined generator
+
+```math
+g_*=71\cdot127\cdot31\pmod{210}.
+```
+
+## 4. The `j=1/2` identification
+
+The `SU(2)` fundamental representation has spin
+
+```math
+j=\frac12.
+```
+
+Its two `J_3` weights are
+
+```math
+\pm\frac12.
+```
+
+The spin-`j` character is
+
+```math
+\chi_j(\theta)=\frac{\sin((2j+1)\theta/2)}{\sin(\theta/2)}.
+```
+
+For `j=1/2`, this becomes
+
+```math
+\chi_{1/2}(\theta)=2\cos(\theta/2).
+```
+
+At the modular order-3 angle `theta=2*pi/3`,
+
+```math
+\chi_{1/2}(2\pi/3)=2\cos(\pi/3)=1.
+```
+
+The same one-half coordinate appears in the finite character table.
+
+For the `P(7)=210` character parametrization,
+
+```math
+\chi_{j,k,l}(g)=(-1)^{j e_2}i^{k e_4}e^{i\pi l e_6/3},
+```
+
+where `(e_2,e_4,e_6)` is the discrete-log coordinate of `g` in the CRT generators.
+
+For the distinguished character at the combined generator,
+
+```math
+\varphi_{1,1,1}(g_*)
+=
+\zeta_2\zeta_4\zeta_6
+=(-1)(i)(e^{i\pi/3})
+=e^{-i\pi/6}
+=
+\frac{\sqrt3}{2}-\frac{i}{2}.
+```
+
+Thus
+
+```math
+\operatorname{Im}(\varphi_{1,1,1}(g_*))=-\frac12=-j.
+```
+
+Also,
+
+```math
+\frac{1}{2i}=-\frac{i}{2},
+\qquad
+\operatorname{Im}\left(\frac{1}{2i}\right)=-\frac12.
+```
+
+The Catalan singularity relation is
+
+```math
+\rho_2=\frac{1}{2(2j+1)}\bigg|_{j=1/2}=\frac14,
+```
+
+and
+
+```math
+\left(\frac{1}{2i}\right)^2=-\frac14=-\rho_2.
+```
+
+The finite structural chain is therefore:
+
+| Object | Appearance of one-half | Role |
+|---|---|---|
+| `j=1/2` SU(2) representation | `J_3` weights `+/-1/2` | fundamental spin quantum number |
+| Critical line | `Re(s)=1/2` | fixed locus of `s -> 1-conj(s)` |
+| `varphi_{1,1,1}(g_*)` | imaginary part `-1/2` | finite character value at combined generator |
+| `cos(pi/3)` | `1/2` | real part of `zeta_6`, modular elliptic coordinate |
+| `1/(2i)` | imaginary part `-1/2` | base imaginary half-unit |
+
+This is a finite arithmetic structural coincidence. It is not a proof that `varphi_{1,1,1}` encodes `SU(2)` representation theory.
+
+A precise Casimir-compatible identity is recorded in the tests:
+
+```math
+\left(\operatorname{Im}(\varphi_{1,1,1}(g_*))\right)^2+\frac12
+=
+\frac14+\frac12
+=
+\frac34
+=
+j(j+1)\quad (j=1/2).
+```
+
+The character value itself remains a root of unity and therefore has unit norm:
+
+```math
+|\varphi_{1,1,1}(g_*)|^2=1.
+```
+
+The unit-norm fact and the `SU(2)` Casimir value are not the same statement.
+
+## 5. Gaussian eigenvalue of the distinguished character
+
+The finite Gaussian eigenvalue of the distinguished character is
+
+```math
+\lambda^{\mathbb Z[i]}_{1,1,1}
+=
+\sum_{h\in G_{210}}A_{\mathbb Z[i]}(h)\varphi_{1,1,1}(h).
+```
+
+This eigenvalue is the finite arithmetic spectral coordinate attached to the `varphi_{1,1,1}` character under the Gaussian integer kernel.
+
+It is a cutoff-dependent finite partial sum. It is not a zero ordinate and not a Hilbert-Polya operator eigenvalue at theorem grade.
+
+## 6. Transfer and Yang-Mills analogy boundary
+
+The `j=1/2` representation is the fundamental spinor representation of `SU(2)`. In strong-coupling lattice `SU(2)` reasoning, Wilson-loop calculations naturally involve the fundamental representation and factors related to `2j+1=2`.
+
+This artifact records only a finite arithmetic analogy:
+
+```math
+\varphi_{1,1,1}(g_*)=e^{-i\pi/6}
+```
+
+has imaginary part `-1/2`, while the `j=1/2` representation has weights `+/-1/2`.
+
+No theorem-grade bridge is asserted between the Gaussian finite operator and continuum Yang-Mills theory.
+
+## 7. Operational substrate
+
+Executable checker:
+
+```text
+tools/check_gaussian_integer_operator.py
+```
+
+Tests:
+
+```text
+tests/test_gaussian_integer_operator.py
+```
+
+Make target:
+
+```text
+make check-gaussian-integer-operator
+```
+
+The checker reuses the existing `P(7)=210` finite character substrate:
+
+```text
+build_dlog_table
+character_value
+eigenvalue_for_character
+raw_prime_residue_kernel
+reduced_residues
+```
+
+## 8. Non-claims
+
+This artifact explicitly does not claim:
+
+1. RH.
+2. GRH.
+3. PNT.
+4. PNT in arithmetic progressions.
+5. Any zero-location theorem.
+6. That `varphi_{1,1,1}` encodes `SU(2)` representation theory at theorem grade.
+7. That the finite Gaussian eigenvalue is a Hilbert-Polya eigenvalue.
+8. That finite Gaussian spectral coordinates determine Riemann zero ordinates.
+9. A Yang-Mills mass gap.
+10. A continuum Yang-Mills construction.
+11. That display modulus `210` equals analytic conductor.
+12. That the Gaussian integer kernel supplies zero-registry zero locations.

--- a/tests/test_gaussian_integer_operator.py
+++ b/tests/test_gaussian_integer_operator.py
@@ -1,0 +1,101 @@
+import cmath
+import math
+
+from tools.check_finite_character_operator import (
+    ALPHA,
+    BETA,
+    GAMMA,
+    MODULUS,
+    PRIME_CUTOFF,
+    build_dlog_table,
+    character_value,
+    reduced_residues,
+)
+from tools.check_gaussian_integer_operator import (
+    PHI_111_INDEX,
+    base_imaginary_half,
+    catalan_singularity_from_j_half,
+    chi_111_at_combined_generator,
+    chi_111_zeta_product,
+    combined_generator,
+    gaussian_eigenvalue,
+    gaussian_integer_for_prime,
+    gaussian_integer_kernel,
+    gaussian_phase,
+    su2_j_half_casimir,
+    zeta2,
+    zeta4,
+    zeta6,
+)
+
+
+def test_gaussian_integer_split_prime_examples():
+    assert gaussian_integer_for_prime(2) == (1, 1)
+    assert gaussian_integer_for_prime(5) == (2, 1)
+    assert gaussian_integer_for_prime(13) == (3, 2)
+    assert gaussian_integer_for_prime(17) == (4, 1)
+    assert gaussian_integer_for_prime(3) is None
+    assert gaussian_integer_for_prime(7) is None
+
+
+def test_gaussian_phase_has_unit_norm():
+    for pair in [(1, 1), (2, 1), (3, 2), (4, 1)]:
+        phase = gaussian_phase(*pair)
+        assert abs(abs(phase) - 1.0) < 1e-12
+
+
+def test_gaussian_kernel_has_full_residue_support_shape():
+    kernel = gaussian_integer_kernel(PRIME_CUTOFF, MODULUS)
+
+    assert set(kernel) == set(reduced_residues(MODULUS))
+    assert len(kernel) == 48
+    assert any(abs(value) > 0 for value in kernel.values())
+
+
+def test_combined_generator_and_chi_111_value():
+    dlog_table = build_dlog_table()
+    g_star = combined_generator()
+    chi = character_value(PHI_111_INDEX, g_star, dlog_table)
+
+    assert g_star == (ALPHA * BETA * GAMMA) % MODULUS
+    assert abs(chi - chi_111_at_combined_generator()) < 1e-12
+    assert abs(chi - chi_111_zeta_product()) < 1e-12
+    assert abs(chi - cmath.exp(-1j * math.pi / 6)) < 1e-12
+    assert abs(chi.imag + 0.5) < 1e-12
+
+
+def test_chi_111_casimir_relation():
+    chi_111_gstar = zeta2() ** 1 * zeta4() ** 1 * zeta6() ** 1
+
+    assert abs(abs(chi_111_gstar) ** 2 - 1.0) < 1e-12
+    assert abs(chi_111_gstar.imag + 0.5) < 1e-12
+
+    j = 0.5
+    spin_component = chi_111_gstar.imag
+    assert abs(spin_component * spin_component + j - j * (j + 1)) < 1e-12
+    assert abs(su2_j_half_casimir() - 0.75) < 1e-12
+
+
+def test_catalan_singularity_from_j_half():
+    j = 0.5
+    rho_2 = 1 / (2 * (2 * j + 1))
+
+    assert abs(rho_2 - 0.25) < 1e-12
+    assert abs(catalan_singularity_from_j_half() - 0.25) < 1e-12
+
+    base_squared = (1 / (2 * 1j)) ** 2
+    assert abs(base_squared + rho_2) < 1e-12
+    assert abs(base_imaginary_half() ** 2 + rho_2) < 1e-12
+
+
+def test_phi_111_gaussian_eigenvalue_is_computable():
+    dlog_table = build_dlog_table()
+    kernel = gaussian_integer_kernel(PRIME_CUTOFF, MODULUS)
+    eigenvalue = gaussian_eigenvalue(PHI_111_INDEX, kernel, dlog_table)
+
+    assert isinstance(eigenvalue, complex)
+    assert abs(eigenvalue) > 0
+
+
+def test_display_modulus_210_is_not_conductor():
+    assert 210 != 105

--- a/tests/test_gaussian_integer_operator.py
+++ b/tests/test_gaussian_integer_operator.py
@@ -72,8 +72,13 @@ def test_chi_111_casimir_relation():
 
     j = 0.5
     spin_component = chi_111_gstar.imag
-    assert abs(spin_component * spin_component + j - j * (j + 1)) < 1e-12
+    casimir_component = spin_component * spin_component + j
+    catalan_component = catalan_singularity_from_j_half()
+
+    assert abs(casimir_component - j * (j + 1)) < 1e-12
+    assert abs(casimir_component - su2_j_half_casimir()) < 1e-12
     assert abs(su2_j_half_casimir() - 0.75) < 1e-12
+    assert abs(casimir_component + catalan_component - 1.0) < 1e-12
 
 
 def test_catalan_singularity_from_j_half():

--- a/tools/check_gaussian_integer_operator.py
+++ b/tools/check_gaussian_integer_operator.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Gaussian-integer finite character-operator diagnostic for P(7)=210.
+
+This diagnostic lifts split rational primes q=a^2+b^2 into unit Gaussian
+phases (a+i b)/sqrt(q), aggregates those phases by residue class modulo 210,
+and evaluates the resulting finite character transform on G_210.
+
+It is finite arithmetic scaffolding only. It does not prove RH, GRH, PNT,
+zero-location, Hilbert-Polya theorem-grade realization, conductor equality,
+or Yang-Mills mass gap.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+import sys
+from pathlib import Path
+from typing import Dict, Mapping, Optional, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.check_finite_character_operator import (
+    ALPHA,
+    BETA,
+    GAMMA,
+    MODULUS,
+    PRIME_CUTOFF,
+    build_dlog_table,
+    character_value,
+    eigenvalue_for_character,
+    raw_prime_residue_kernel,
+    reduced_residues,
+)
+
+PHI_111_INDEX = (1, 1, 1)
+
+
+def _is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n == 2:
+        return True
+    if n % 2 == 0:
+        return False
+    d = 3
+    while d * d <= n:
+        if n % d == 0:
+            return False
+        d += 2
+    return True
+
+
+def gaussian_integer_for_prime(prime: int) -> Optional[Tuple[int, int]]:
+    """Return canonical a,b>=0 with a^2+b^2=prime for split primes."""
+
+    if prime == 2:
+        return (1, 1)
+    if prime % 4 != 1:
+        return None
+    limit = math.isqrt(prime)
+    for a in range(1, limit + 1):
+        b2 = prime - a * a
+        b = math.isqrt(b2)
+        if b * b == b2:
+            return (max(a, b), min(a, b))
+    return None
+
+
+def gaussian_phase(a: int, b: int) -> complex:
+    norm = math.sqrt(a * a + b * b)
+    return complex(a / norm, b / norm)
+
+
+def gaussian_integer_kernel(cutoff: int = PRIME_CUTOFF, modulus: int = MODULUS) -> Dict[int, complex]:
+    """Aggregate log(q)*(a+i b)/sqrt(q) by q mod modulus for split primes."""
+
+    kernel = {h: 0j for h in reduced_residues(modulus)}
+    raw = raw_prime_residue_kernel(cutoff, modulus)
+    for q in range(2, cutoff + 1):
+        if not _is_prime(q):
+            continue
+        residue = q % modulus
+        if math.gcd(residue, modulus) != 1:
+            continue
+        pair = gaussian_integer_for_prime(q)
+        if pair is None:
+            continue
+        a, b = pair
+        kernel[residue] += math.log(q) * gaussian_phase(a, b)
+    if set(kernel) != set(raw):
+        raise AssertionError("gaussian kernel support diverged from raw residue support")
+    return kernel
+
+
+def gaussian_eigenvalue(index, kernel: Mapping[int, complex], dlog_table) -> complex:
+    return eigenvalue_for_character(index, kernel, dlog_table)
+
+
+def combined_generator(modulus: int = MODULUS) -> int:
+    return (ALPHA * BETA * GAMMA) % modulus
+
+
+def zeta2() -> complex:
+    return -1 + 0j
+
+
+def zeta4() -> complex:
+    return 1j
+
+
+def zeta6() -> complex:
+    return cmath.exp(1j * math.pi / 3)
+
+
+def chi_111_at_combined_generator() -> complex:
+    dlog_table = build_dlog_table()
+    return character_value(PHI_111_INDEX, combined_generator(), dlog_table)
+
+
+def chi_111_zeta_product() -> complex:
+    return zeta2() * zeta4() * zeta6()
+
+
+def su2_j_half_casimir() -> float:
+    j = 0.5
+    return j * (j + 1.0)
+
+
+def catalan_singularity_from_j_half() -> float:
+    j = 0.5
+    return 1.0 / (2.0 * (2.0 * j + 1.0))
+
+
+def base_imaginary_half() -> complex:
+    return 1.0 / (2.0 * 1j)
+
+
+def run_checks():
+    dlog_table = build_dlog_table()
+    kernel = gaussian_integer_kernel(PRIME_CUTOFF, MODULUS)
+    eigenvalue = gaussian_eigenvalue(PHI_111_INDEX, kernel, dlog_table)
+
+    if len(kernel) != 48:
+        raise AssertionError("expected 48 residue slots for G_210")
+    if abs(chi_111_at_combined_generator() - chi_111_zeta_product()) > 1e-12:
+        raise AssertionError("chi_111(g*) must equal zeta2*zeta4*zeta6")
+    if abs(chi_111_at_combined_generator().imag + 0.5) > 1e-12:
+        raise AssertionError("Im chi_111(g*) must be -1/2")
+    if abs(abs(chi_111_at_combined_generator()) ** 2 - 1.0) > 1e-12:
+        raise AssertionError("character value must have unit norm")
+    spin_component = chi_111_at_combined_generator().imag
+    if abs(spin_component * spin_component + 0.5 - su2_j_half_casimir()) > 1e-12:
+        raise AssertionError("spin-component Casimir relation failed")
+    if abs(catalan_singularity_from_j_half() - 0.25) > 1e-12:
+        raise AssertionError("j=1/2 Catalan singularity relation failed")
+    if abs(base_imaginary_half() ** 2 + catalan_singularity_from_j_half()) > 1e-12:
+        raise AssertionError("(1/(2i))^2 = -rho_2 relation failed")
+
+    return eigenvalue
+
+
+def main() -> None:
+    eigenvalue = run_checks()
+    chi = chi_111_at_combined_generator()
+    print("gaussian integer character operator checks passed")
+    print(f"modulus: {MODULUS}")
+    print(f"prime cutoff: {PRIME_CUTOFF}")
+    print(f"combined generator g*: {combined_generator()}")
+    print(f"chi_111(g*): {chi.real:.12f}{chi.imag:+.12f}i")
+    print(f"Im chi_111(g*): {chi.imag:.12f}")
+    print(f"j=1/2 Casimir: {su2_j_half_casimir():.12f}")
+    print(f"Catalan rho_2 from j=1/2: {catalan_singularity_from_j_half():.12f}")
+    print(f"phi_111 gaussian eigenvalue: {eigenvalue.real:.12f}{eigenvalue.imag:+.12f}i")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `HW-PRIME-GAUSSIAN-INT-001`, a finite Gaussian-integer character-operator diagnostic for the P(7)=210 prime/operator lane.

Changes:

- adds `tools/check_gaussian_integer_operator.py`;
- adds `tests/test_gaussian_integer_operator.py`;
- adds `docs/prime-operator-lane/gaussian-integer-operator-diagnostic.md`;
- adds `make check-gaussian-integer-operator`.

## j=1/2 identification

Records the finite structural chain connecting:

- `j=1/2` SU(2) weights `+/-1/2`;
- the critical-line center `Re(s)=1/2`;
- `varphi_{1,1,1}(g*) = zeta_2 zeta_4 zeta_6 = e^{-i*pi/6}` with imaginary part `-1/2`;
- `cos(pi/3)=1/2`;
- `1/(2i)=-i/2`.

The tests enforce the `Im varphi_{1,1,1}(g*)=-1/2` relation and the Catalan singularity relation `rho_2=1/(2(2j+1))=1/4` for `j=1/2`.

## Correction recorded

`|varphi_{1,1,1}(g*)|^2=1` because it is a root of unity. The Casimir-compatible CI assertion is the corrected identity `(Im varphi_{1,1,1}(g*))^2 + 1/2 = 3/4 = j(j+1)` for `j=1/2`.

## Scope

No CI wiring in this PR. No new dependencies. No RH, GRH, PNT, zero-location, Hilbert-Polya theorem-grade, conductor-equality, SU(2) theorem-grade, or Yang-Mills mass-gap claim.