### PR TITLE
docs: add Ehrhart section to repunit diagnostic

### DIFF
--- a/docs/prime-operator-lane/prime-window-repunit-diagnostic.md
+++ b/docs/prime-operator-lane/prime-window-repunit-diagnostic.md
@@ -226,6 +226,74 @@ The window operator `T_hat_{W_k}` is a restriction of that finite operator to a 
 
 Thus `HW-PRIME-WINDOW-001` does not replace `HW-PRIME-FINITE-OPERATOR-001`. It refines it by adding digit-window localization and repunit-resonance diagnostics.
 
+## 8. Ehrhart polynomial — discrete side of zeta
+
+The Ehrhart polynomial of a lattice polytope `P` counts lattice points in dilates:
+
+```text
+L(P,t) = |tP cap Z^d|,  t in N.
+```
+
+For the standard `d`-simplex `Delta_d` with vertices at the origin and the `d` coordinate points,
+
+```text
+L(Delta_d,t) = binom(t+d,d).
+```
+
+At unit dilation,
+
+```text
+L(Delta_0,1)=1,
+L(Delta_1,1)=2,
+L(Delta_2,1)=3.
+```
+
+Thus the digit sequence of the repunit additive sum is the Ehrhart simplex sequence at unit dilation:
+
+```text
+R_1 + ... + R_n = 123...n,
+left digit k = L(Delta_{k-1},1)=k,
+```
+
+for `1 <= n <= 9` in base 10.
+
+The Ehrhart series is
+
+```text
+Ehr(P,z) = sum_{t>=0} L(P,t) z^t = h*(z)/(1-z)^(d+1).
+```
+
+For the unit hypercube `[0,1]^d`, this gives
+
+```text
+Ehr([0,1]^d,z) = sum_{t>=0} (t+1)^d z^t = sum_{n>=1} n^d z^(n-1).
+```
+
+After substituting `z=e^{-u}`, the Mellin transform gives the zeta bridge:
+
+```text
+int_0^infinity u^(s-1) Ehr([0,1]^d,e^{-u}) du = Gamma(s) zeta(s-d).
+```
+
+This is the analytic bridge from discrete lattice counting to the Riemann zeta function.
+
+The Euler-Mascheroni constant is simultaneously the constant term in the Laurent expansion of zeta at the pole and the leading residual in the discrete-to-continuous Euler-Maclaurin correction. On the Ehrhart side it records the leading error between lattice counts and the corresponding continuous volume approximation, accumulated across dilates.
+
+Ehrhart-Macdonald reciprocity states:
+
+```text
+L(P,-t) = (-1)^d L(P^circ,t).
+```
+
+This is the discrete functional-equation analogue: it exchanges the polytope with its interior and introduces the parity sign. For the 2-simplex,
+
+```text
+L(Delta_2,t) = (t+1)(t+2)/2,
+L(Delta_2,-t) = (t-1)(t-2)/2 = L(Delta_2^circ,t).
+```
+
+The vanishing of the interior lattice count at small dilations is the Ehrhart-side finite analogue of discrete-side zeros. This diagnostic does not identify nontrivial zeta zeros.
+
 ## Non-claims
 
 This document does not predict the next prime.

--- a/tests/test_prime_window_repunit_diagnostic.py
+++ b/tests/test_prime_window_repunit_diagnostic.py
@@ -1,4 +1,4 @@
-from math import gcd
+from math import comb, gcd
 
 
 def dr(n: int) -> int:
@@ -57,3 +57,32 @@ def test_repunit_resonance_condition() -> None:
         order = ord10(p)
         for k in range(1, 13):
             assert (repunit(k) % p == 0) == (k % order == 0)
+
+
+def test_ehrhart_simplex_sequence_matches_repunit_digits() -> None:
+    # L(Delta_{k-1}, 1) = k for k=1,2,...,8.
+    for k in range(1, 9):
+        l_delta = comb(1 + k - 1, k - 1)
+        assert l_delta == k
+
+
+def test_ehrhart_sum_equals_phi_9_at_n_3() -> None:
+    phi9 = sum(1 for k in range(1, 10) if gcd(k, 9) == 1)
+    ehrhart_sum = sum(comb(1 + d, d) for d in range(3))
+
+    assert ehrhart_sum == 6
+    assert phi9 == 6
+    assert ehrhart_sum == phi9
+
+
+def test_ehrhart_macdonald_reciprocity_2_simplex() -> None:
+    # L(Delta_2,t) = (t+1)(t+2)/2.
+    # L(Delta_2,-t) = (t-1)(t-2)/2 = L(Delta_2^interior,t).
+    def l_delta_2(t: int) -> int:
+        return (t + 1) * (t + 2) // 2
+
+    def l_delta_2_interior(t: int) -> int:
+        return (t - 1) * (t - 2) // 2
+
+    for t in range(1, 8):
+        assert l_delta_2(-t) == l_delta_2_interior(t)


### PR DESCRIPTION
## Summary

Adds the Ehrhart polynomial / discrete zeta connection to `HW-PRIME-WINDOW-001`.

Files:

- `docs/prime-operator-lane/prime-window-repunit-diagnostic.md`
- `tests/test_prime_window_repunit_diagnostic.py`

## Scope

Follow-on documentation and tests only. No theorem expansion, no RH/Hilbert-Pólya claim, no Clay claim, and no downstream work.