### PR TITLE
docs: extend open-problems register with Stieltjes boundary

### DIFF
--- a/docs/prime-operator-lane/open-problems-register.md
+++ b/docs/prime-operator-lane/open-problems-register.md
@@ -18,6 +18,8 @@ Problem: construct a self-adjoint operator on a natural infinite-dimensional Hil
 
 Current boundary: the finite `P(7)=210` character-operator eigenvalues approximate finite cutoff character sums. The antisymmetric operator `-iC_{K^-}` gives spectral-coordinate approximations to imaginary parts in the finite model. The gap between finite approximation and actual zero location is the entire open content.
 
+Stieltjes tower refinement. The gap between the finite operator eigenvalue `lambda_chi(B)` approximating spectral data at cutoff `B` and the actual zero ordinate is governed by the Stieltjes constants. The `n`-th order correction to the eigenvalue approximation involves `gamma_n` — the `n`-th moment of the accumulated discrete-to-continuous error between the finite prime sum and its integral approximation. The full tower `{gamma_n}` would need to be controlled to close the gap between the finite operator eigenvalue and the actual spectral data. This is the analytic content of `HW-OPEN-001` stated precisely. The finite program approximates the leading correction; the full tower is not computable from the finite operator alone.
+
 Non-claim: the finite operators do not prove RH, do not identify zero ordinates, and do not construct a Hilbert-Pólya operator.
 
 ## HW-OPEN-002 — Puiseux coefficient general pattern
@@ -55,6 +57,24 @@ Problem: generalize the carry mechanism to `Z[omega]`-valued carry at `p=3`, whe
 Prerequisite: the `p=3` encoding hypothesis must become theorem-grade in Heller-Godel before this can be used as more than a finite arithmetic diagnostic.
 
 Non-claim: this register entry does not assert that the Eisenstein carry construction exists, proves any zero-location statement, or supplies a Yang-Mills mass gap.
+
+## HW-OPEN-004 — Cardinality gap and continuum completion
+
+Finite scaffolding:
+
+- `HW-PRIME-FINITE-OPERATOR-001`
+- `HW-PRIME-ANTISYM-OPERATOR-001`
+- `HW-PRIME-GAUSSIAN-INT-001`
+
+Problem: the finite operator `T_210` lives on a 48-dimensional complex Hilbert space — finite, therefore countable. The Hilbert-Pólya operator, if it exists, must live on an infinite-dimensional Hilbert space over `R` whose eigenvalues are the Riemann zero ordinates. That target object requires continuum completion.
+
+The gap between finite and continuum is not merely one of dimension. It is a cardinality and completion jump from finite/countable scaffolding to continuum analysis. No countable tower of corrections — including the full Stieltjes tower `{gamma_n}` — bridges this gap by itself. The continuum requires distributional completion. The Hilbert-Pólya operator, if it exists, lives in a space of tempered distributions or a similar analytic completion, not in the bare inductive limit of the finite operators.
+
+This is why the problem is hard: it is not an approximation problem with a convergent sequence of finite corrections. It is a completion problem requiring a fundamentally different construction.
+
+Current boundary: the finite program builds the best computable finite approximation to the spectral structure. The cardinality/completion gap between the finite approximation and the actual spectral problem is not closeable by adding more primes to the cutoff or enlarging `G_P`. It requires a different mathematical object.
+
+Non-claim: this entry does not assert that the Hilbert-Pólya operator does not exist. It records precisely why the finite arithmetic scaffolding cannot construct it directly.
 
 ## Register non-claim
 


### PR DESCRIPTION
## Summary

Updates `docs/prime-operator-lane/open-problems-register.md` to:

- add a Stieltjes tower refinement to `HW-OPEN-001`;
- append `HW-OPEN-004` for the cardinality/completion gap between finite operator scaffolding and continuum Hilbert-Pólya-style completion.

## Scope

Single-file documentation PR only. No CI wiring. No theorem claim, no RH/Hilbert-Pólya construction, no Clay claim, and no downstream repo work.