### PR TITLE
docs: add p-adic base structure surface

### DIFF
--- a/docs/prime-operator-lane/p-adic-base-structure.md
+++ b/docs/prime-operator-lane/p-adic-base-structure.md
@@ -87,10 +87,16 @@ FC_n^(p) = binom(pn,n) / ((p-1)n + 1).
 Their p-adic valuation is governed by Kummer's theorem. The binomial part satisfies
 
 ```text
-v_p binom(pn,n) = ((p-1)n - s_p((p-1)n)) / (p-1),
+v_p binom(pn,n) = s_p((p-1)n) / (p-1),
 ```
 
-where `s_p(m)` is the sum of the base-`p` digits of `m`.
+where `s_p(m)` is the sum of the base-`p` digits of `m`. The related Legendre expression
+
+```text
+((p-1)n - s_p((p-1)n)) / (p-1)
+```
+
+computes `v_p(((p-1)n)!)`, not this binomial valuation.
 
 Thus the p-adic valuation of the generating-function coefficients is controlled by base-`p` digit sums. The p-adic base makes the integrality structure of the Fuss-Catalan coefficients visible digit by digit.
 
@@ -101,7 +107,7 @@ binom(6,2) = 15,
 v_3(15) = 1,
 (p-1)n = 4,
 s_3(4) = s_3(11_3) = 2,
-((p-1)n - s_p((p-1)n))/(p-1) = (4-2)/2 = 1.
+s_p((p-1)n)/(p-1) = 2/2 = 1.
 ```
 
 This is recorded as a section boundary and finite diagnostic, not as a new theorem.

--- a/docs/prime-operator-lane/p-adic-base-structure.md
+++ b/docs/prime-operator-lane/p-adic-base-structure.md
@@ -1,0 +1,165 @@
+# HW-PRIME-PADIC-001 — p-adic Base Structure
+
+Identifier: `HW-PRIME-PADIC-001`  
+Status: finite arithmetic / local-factor structure note  
+Claim class: governance / diagnostic structure  
+Mathematical content added by this document: local-factor scaffolding and open-boundary accounting only
+
+This document records the p-adic base structure beneath the profinite prime-operator lane.
+
+## 1. The p-adic base as the foundational level
+
+For each prime `p`, the p-adic integers `Z_p` are the completion of `Z` under the p-adic norm
+
+```text
+|n|_p = p^(-v_p(n)),
+```
+
+where `v_p(n)` is the largest exponent such that `p^v_p(n)` divides `n`.
+
+Every p-adic integer has a unique base-`p` expansion running leftward:
+
+```text
+x = sum_{k=0}^infinity d_k p^k,    d_k in {0,1,...,p-1}.
+```
+
+This is base `p` with infinitely many digits going toward higher powers, the exact reversal of the real base-`p` expansion.
+
+Negative integers are infinite left-expansions. In `Z_p`,
+
+```text
+-1 = (p-1) + (p-1)p + (p-1)p^2 + ... .
+```
+
+Indeed, the finite partial sum through `p^(k-1)` is congruent to `-1 mod p^k`.
+
+## 2. The p-adic carry and the Witt vector tower
+
+The carry in p-adic base-`p` addition is
+
+```text
+kappa_p(a_bar,b_bar) = (a + b - ((a+b) mod p)) / p.
+```
+
+For base digits `a,b in {0,...,p-1}`, this value is either `0` or `1`.
+
+This is the degree-0 Witt vector carry: the first carry digit in `W(F_p)=Z_p`. It is exactly the `HG-FND-007` carry at level `L=p`.
+
+The full Witt vector addition formula extends this to all digit positions. The `n`-th carry `kappa_n` is the degree-`n` term in the p-adic base-`p` expansion of the carry defect.
+
+Thus the carry tower
+
+```text
+(kappa_0, kappa_1, kappa_2, ...)
+```
+
+is the complete p-adic base-`p` expansion of the section defect. `HG-FND-007` normalizes `kappa_0`; `HW-OPEN-003` asks for the Eisenstein / `p=3` extension to the full tower.
+
+## 3. The Teichmuller character as p-adic base lift
+
+The Teichmuller character `omega_p` is the unique multiplicative lift satisfying
+
+```text
+omega_p(a) == a mod p,
+omega_p(a)^(p-1) = 1.
+```
+
+In base-`p` expansion,
+
+```text
+omega_p(a) = a + c_1 p + c_2 p^2 + ...,
+```
+
+where the digits `c_i` are uniquely determined by the multiplicative condition.
+
+The character `chi_3` in `HG-MTH-018` is the reduction of the `p=3` Teichmuller representative modulo `3`. The p-adic base makes the lift from `F_p^x` to `Z_p^x` explicit digit by digit.
+
+This document does not promote that bridge to theorem grade. It records the local-factor interpretation that a later normalized bridge may use.
+
+## 4. p-adic valuation of Fuss-Catalan numbers
+
+The arity-`p` Fuss-Catalan numbers are
+
+```text
+FC_n^(p) = binom(pn,n) / ((p-1)n + 1).
+```
+
+Their p-adic valuation is governed by Kummer's theorem. The binomial part satisfies
+
+```text
+v_p binom(pn,n) = ((p-1)n - s_p((p-1)n)) / (p-1),
+```
+
+where `s_p(m)` is the sum of the base-`p` digits of `m`.
+
+Thus the p-adic valuation of the generating-function coefficients is controlled by base-`p` digit sums. The p-adic base makes the integrality structure of the Fuss-Catalan coefficients visible digit by digit.
+
+Boundary check at `p=3`, `n=2`:
+
+```text
+binom(6,2) = 15,
+v_3(15) = 1,
+(p-1)n = 4,
+s_3(4) = s_3(11_3) = 2,
+((p-1)n - s_p((p-1)n))/(p-1) = (4-2)/2 = 1.
+```
+
+This is recorded as a section boundary and finite diagnostic, not as a new theorem.
+
+## 5. The profinite decomposition
+
+The profinite completion decomposes as
+
+```text
+Z_hat ~= product_p Z_p,
+Z_hat^x ~= product_p Z_p^x.
+```
+
+The `L^2` space of the profinite completion decomposes as a restricted tensor product
+
+```text
+L^2(Z_hat^x) ~= restricted_tensor_product_p L^2(Z_p^x),
+```
+
+with respect to the finite-level Haar structures.
+
+The characters of `Z_hat^x`, i.e. all finite-conductor Dirichlet characters simultaneously, factor as products of p-adic characters:
+
+```text
+chi = product_p chi_p,
+```
+
+where `chi_p` is a character of `Z_p^x` at the local factor.
+
+The inductive-limit operator `T_infinity` decomposes accordingly at the Euler-factor level. Its character-indexed eigenvalue data are represented by the Euler product
+
+```text
+lambda_chi = product_p lambda_chi_p^(p)
+  <->
+L(s,chi) = product_p (1 - chi(p)p^(-s))^(-1).
+```
+
+The p-adic base provides one local factor per prime. The zeros of `L(s,chi)` belong to the global analytic-continuation problem, not to any single local p-adic factor. The spectral problem is the problem of controlling the product over all p-adic bases simultaneously.
+
+## 6. Placement in the base hierarchy
+
+The p-adic base is the bottom level of the hierarchy identified in `HW-OPEN-006`. Every other natural base in the prime-operator lane is related to it:
+
+- `zeta_p` and `omega` are roots of unity visible through local p-adic and cyclotomic structures;
+- `i = zeta_4` is the cyclotomic unit governing the Gaussian-integer operator split;
+- `e`, `pi`, and `gamma` are transcendental completion coordinates, modeled globally through rational approximations and adelic comparison surfaces;
+- the carry `kappa_p` is the degree-0 Witt vector carry in `Z_p`.
+
+The p-adic base is therefore not merely one base among many. It is the local arithmetic base whose product over all primes yields the profinite completion used in `HW-PRIME-PROFINITE-001`.
+
+## 7. Non-claims
+
+This document does not prove RH or GRH.
+
+This document does not construct a Hilbert-Pólya operator.
+
+This document does not identify `chi_3` with the full Teichmuller character at theorem grade; that requires a separate normalized bridge.
+
+This document does not prove that the Euler product converges at the zeros.
+
+This document does not assert the tensor-product decomposition of `L^2(Z_hat^x)` as a theorem-grade result inside this repository. It records the intended structural decomposition and the boundary conditions needed for future normalization.

--- a/tests/test_p_adic_base_structure.py
+++ b/tests/test_p_adic_base_structure.py
@@ -60,7 +60,10 @@ def test_negative_one_in_padic_base():
 def test_fuss_catalan_padic_valuation():
     for p in [2, 3]:
         for n in range(1, 6):
-            kummer_val = ((p - 1) * n - digit_sum_base_p((p - 1) * n, p)) // (p - 1)
+            # Kummer: v_p(C(pn,n)) = s_p((p-1)n)/(p-1).
+            # The Legendre expression ((p-1)n - s_p((p-1)n))/(p-1)
+            # instead computes v_p(((p-1)n)!), not this binomial valuation.
+            kummer_val = digit_sum_base_p((p - 1) * n, p) // (p - 1)
             binom_val = v_p(comb(p * n, n), p)
             assert kummer_val == binom_val
 

--- a/tests/test_p_adic_base_structure.py
+++ b/tests/test_p_adic_base_structure.py
@@ -1,0 +1,107 @@
+from math import comb, gcd
+from fractions import Fraction
+
+
+def v_p(n, p):
+    """p-adic valuation of nonzero integer n."""
+    if n == 0:
+        return float("inf")
+    v = 0
+    while n % p == 0:
+        n //= p
+        v += 1
+    return v
+
+
+def digit_sum_base_p(n, p):
+    """Sum of digits of n in base p."""
+    s = 0
+    while n > 0:
+        s += n % p
+        n //= p
+    return s
+
+
+def fc(n, p):
+    """Fuss-Catalan number FC_n^(p) = C(pn,n)/((p-1)n+1)."""
+    return comb(p * n, n) // ((p - 1) * n + 1)
+
+
+def witt_carry(a, b, p):
+    """Degree-0 Witt vector carry at prime p."""
+    return (a + b - (a + b) % p) // p
+
+
+def teichmuller_mod_p_sq(a, p):
+    """Teichmuller lift omega_p(a) mod p^2."""
+    for x in range(a, p * p, p):
+        if pow(x, p - 1, p * p) == 1:
+            return x
+    return None
+
+
+def test_padic_carry_matches_hg_fnd_007():
+    for p in [2, 3, 5]:
+        for a in range(p):
+            for b in range(p):
+                carry = witt_carry(a, b, p)
+                assert carry in (0, 1)
+                assert carry == int((a + b) >= p)
+
+
+def test_negative_one_in_padic_base():
+    for p in [2, 3, 5, 7]:
+        for k in range(1, 8):
+            partial = sum((p - 1) * p**j for j in range(k))
+            assert partial % p**k == p**k - 1
+            assert (partial + 1) % p**k == 0
+
+
+def test_fuss_catalan_padic_valuation():
+    for p in [2, 3]:
+        for n in range(1, 6):
+            kummer_val = ((p - 1) * n - digit_sum_base_p((p - 1) * n, p)) // (p - 1)
+            binom_val = v_p(comb(p * n, n), p)
+            assert kummer_val == binom_val
+
+
+def test_teichmuller_lift_is_multiplicative():
+    p = 5
+    for a in range(1, p):
+        for b in range(1, p):
+            wa = teichmuller_mod_p_sq(a, p)
+            wb = teichmuller_mod_p_sq(b, p)
+            wab = teichmuller_mod_p_sq((a * b) % p, p)
+            assert (wa * wb) % (p * p) == wab
+
+
+def test_teichmuller_reduces_to_character():
+    for p in [3, 5, 7]:
+        for a in range(1, p):
+            w = teichmuller_mod_p_sq(a, p)
+            assert w % p == a
+
+
+def test_profinite_crt_decomposition():
+    P = 30
+    primes = [2, 3, 5]
+    for n in range(P):
+        residues = tuple(n % p for p in primes)
+        reconstructed = 0
+        for p, r in zip(primes, residues):
+            Mi = P // p
+            inv = pow(Mi, -1, p)
+            reconstructed += r * Mi * inv
+        assert reconstructed % P == n % P
+
+
+def test_euler_product_partial_at_trivial_character():
+    import math
+
+    primes = [p for p in range(2, 50) if all(p % d != 0 for d in range(2, p))]
+    s = 2
+    partial_product = 1.0
+    for p in primes:
+        partial_product *= 1 - p ** (-s)
+    expected = 6 / math.pi**2
+    assert abs(partial_product - expected) < 0.1


### PR DESCRIPTION
## Summary

Adds `HW-PRIME-PADIC-001`, documenting the p-adic base structure beneath the profinite prime-operator lane, with stdlib guards for carry, negative-one expansion, Kummer valuation, Teichmuller lifts, CRT decomposition, and Euler-product partial behavior.

## Scope

Documentation/tests only. No RH/GRH proof, no Hilbert-Polya construction, no theorem-grade Teichmuller bridge, no zero-convergence claim, and no theorem-grade tensor-product assertion.