### PR TITLE
docs: add finite Weil positivity approach

### DIFF
--- a/docs/prime-operator-lane/weil-positivity-approach.md
+++ b/docs/prime-operator-lane/weil-positivity-approach.md
@@ -1,0 +1,195 @@
+# HW-PRIME-WEIL-001 — Finite Weil Positivity Approach
+
+Identifier: `HW-PRIME-WEIL-001`  
+Status: finite positivity / growth-rate diagnostic / conditional-limit approach  
+Claim class: diagnostic theorem surface plus open convergence boundary  
+Mathematical content added by this document: finite positivity theorem, growth-rate diagnostic, and conditional convergence framing only
+
+This document records the non-circular positivity route exposed by the prime-operator lane.
+
+The direct Hilbert-Pólya route is blocked by a familiar circularity: proving essential self-adjointness of the limit operator requires tail control strong enough to encode the spectral statement being sought. The finite Weil-positivity route avoids that direct circularity by proving positivity at each finite primorial level first, then isolating the separate open problems of growth-rate control and positivity propagation to the limiting Weil distribution.
+
+## 1. Gaussian-smoothed finite operator
+
+For a character `chi`, define the prime-weighted raw character sum
+
+```text
+psi(B,chi) = sum_{p <= B} (log p) chi(p).
+```
+
+The raw sums do not converge directly to `-L'/L(0,chi)`. They oscillate with growing amplitude.
+
+To move from raw cutoff sums to Weil-compatible test functions, define the Gaussian-smoothed finite eigenvalue
+
+```text
+lambda_chi^(sigma)(B)
+  = sum_{p <= B} (log p) chi(p) exp(-(log p)^2/(2 sigma^2)).
+```
+
+For large `sigma`, this approaches the raw finite sum. For finite `sigma`, it suppresses the hard cutoff and places the computation inside the explicit-formula test-function regime.
+
+## 2. Finite Weil distribution
+
+For a primorial level `P_k`, let
+
+```text
+G_k = (Z/P_k Z)^x,
+H_k = C[G_k].
+```
+
+The finite Haar inner product is
+
+```text
+<f,g>_k = (1/|G_k|) sum_{x in G_k} f(x) conjugate(g(x)).
+```
+
+The character basis `G_k^` is orthonormal for this inner product.
+
+The Gaussian-smoothed positive finite Weil distribution is
+
+```text
+W_{k,sigma}^pos(h)
+  = (1/|G_k|) sum_{chi in G_k^} |h_hat(chi)|^2 |lambda_chi^(sigma)(P_k)|^2.
+```
+
+Equivalently, the positive kernel is the autocorrelation / squared-spectrum kernel. Its Fourier transform is `|lambda_chi^(sigma)(P_k)|^2`, hence non-negative for every character.
+
+## 3. Finite positivity theorem
+
+Finite theorem: for every `h in H_k`,
+
+```text
+W_{k,sigma}^pos(h) >= 0.
+```
+
+Proof: each summand in
+
+```text
+(1/|G_k|) sum_chi |h_hat(chi)|^2 |lambda_chi^(sigma)|^2
+```
+
+is non-negative. Thus the sum is non-negative. Equality holds precisely on the kernel of the squared finite operator, i.e. on the subspace whose character coefficients vanish wherever `lambda_chi^(sigma) != 0`.
+
+This theorem is finite and non-circular. It does not assume RH, GRH, essential self-adjointness, or any limiting spectral theorem.
+
+## 4. GRH signature and growth exponent
+
+The explicit formula gives the schematic relation
+
+```text
+psi(B,chi) = - sum_rho B^rho/rho + lower-order and trivial terms,
+```
+
+where `rho` ranges over nontrivial zeros of the corresponding `L`-function.
+
+Thus the growth exponent
+
+```text
+alpha(chi) = limsup_{B -> infinity} log |psi(B,chi)| / log B
+```
+
+is the spectral diagnostic. Under GRH for `L(s,chi)`, one expects
+
+```text
+|psi(B,chi)| = O(B^(1/2) log^2 B),
+```
+
+so `alpha(chi) <= 1/2`. If a zero has real part `beta > 1/2`, the explicit formula permits growth at exponent at least `beta`.
+
+The corrected attack is therefore not raw eigenvalue convergence. It is growth-rate control of the cutoff sums.
+
+## 5. Three theorem statements
+
+Theorem 1, finite Weil positivity, proved at finite level:
+
+```text
+W_{k,sigma}^pos(h) >= 0
+```
+
+for all finite `k`, all `sigma > 0`, and all `h in H_k`.
+
+Theorem 2, GRH signature, numerical / conditional:
+
+```text
+|psi(B,chi)| / sqrt(B) < log(B)^2
+```
+
+is the finite-scale GRH-signature test. It is consistent with GRH but does not prove GRH.
+
+Theorem 3, conditional RH / GRH target:
+
+If
+
+(A) for all finite-level characters, the growth exponent `alpha(chi)` remains `<= 1/2` uniformly in the profinite inductive limit, and
+
+(B) the Gaussian-smoothed finite Weil distributions `W_{k,sigma}^pos` converge weakly to the full Weil distribution as `k -> infinity` and the smoothing parameter is removed in the declared test-function topology,
+
+then the Weil positivity criterion holds for the relevant test-function class, and the corresponding RH / GRH statement follows for the associated `L`-function family.
+
+This third theorem is a target statement, not a theorem currently proved in this repository.
+
+## 6. Numerical evidence at the `P_4=210` character family
+
+For the 48-character family of `(Z/210Z)^x`, the Gaussian-smoothed finite Weil distribution is strictly positive in the tested windows:
+
+| `B` | `W_{sigma}^pos(1)` | `min_chi |lambda_chi^(sigma)(B)|` |
+| ---: | ---: | ---: |
+| 200 | `53.5` | `0.339` |
+| 500 | `313.7` | `0.509` |
+| 1000 | `1131.8` | `1.008` |
+
+All tested characters have nonzero Gaussian-smoothed eigenvalue weight at these windows. This is finite evidence for the squared-spectrum positivity surface.
+
+For the GRH-signature ratio at `B=500`, the tested maximum satisfies
+
+```text
+max_chi |psi(B,chi)|/sqrt(B) < log(B)^2.
+```
+
+The bound is not saturated. This is numerical evidence consistent with the `B^(1/2) log^2 B` signature, not a proof.
+
+Moderate-scale growth exponents are noisy: individual zero oscillations dominate at this scale, and short-window ratios across `B=200` and `B=500` should not be treated as stable asymptotic evidence.
+
+## 7. Relation to Ehrhart and repunit window data
+
+`HW-PRIME-WINDOW-001` and the Ehrhart section identify a discrete lattice-counting symmetry and reciprocity structure. Ehrhart-Macdonald reciprocity supplies a finite discrete analogue of functional-equation symmetry.
+
+The finite Weil distribution above supplies positivity at the finite Haar-measure level. The missing bridge is the convergence of finite positivity to the full Weil distribution on the correct test-function space.
+
+Thus the finite arithmetic program supplies:
+
+1. finite Haar positivity;
+2. finite character orthogonality;
+3. finite autocorrelation positivity;
+4. Gaussian-smoothed finite positive distributions;
+5. GRH-signature finite diagnostics;
+6. Ehrhart-style reciprocity diagnostics;
+7. a profinite completion surface.
+
+The analytic continuation / Weil criterion remains an open boundary.
+
+## 8. Relation to Lane VIII Borel-Stieltjes scope
+
+The Lane VIII Borel-Stieltjes scope in the Yang-Mills repository records the Borel-Laplace / transseries treatment of the Stieltjes correction tower from the continuum side.
+
+Here the same correction tower appears as the finite-to-limit error control surface for prime-operator growth-rate data and finite Weil positivity propagation.
+
+The two framings are not identical, but they point to the same analytic obstruction: whether the discrete-to-continuous correction tower is controlled strongly enough to preserve positivity and growth-rate bounds in the limit.
+
+## 9. Non-claims
+
+This document does not prove RH or GRH.
+
+This document does not construct a Hilbert-Pólya operator.
+
+This document does not prove essential self-adjointness of `T_infinity`.
+
+This document does not assert that the raw symmetric finite operator is positive.
+
+This document does not assert that raw finite eigenvalues converge to `-L'/L(0,chi)`.
+
+This document does not assert that the finite GRH-signature ratio proves GRH.
+
+This document does not assert strict Borel summability of the Stieltjes tower; renormalon or transseries corrections are explicitly part of the open boundary.
+
+This document does not assert that finite positivity has been propagated to the full Weil distribution.

--- a/tests/test_weil_positivity.py
+++ b/tests/test_weil_positivity.py
@@ -1,0 +1,159 @@
+import cmath
+import math
+from math import gcd, log, sqrt
+
+
+PRIMES_MODULUS = [2, 3, 5, 7]
+P4 = math.prod(PRIMES_MODULUS)
+
+
+def is_prime(n):
+    if n < 2:
+        return False
+    for d in range(2, int(math.sqrt(n)) + 1):
+        if n % d == 0:
+            return False
+    return True
+
+
+def primes_upto(B):
+    return [n for n in range(2, B + 1) if is_prime(n)]
+
+
+def units_mod(P):
+    return [g for g in range(1, P) if gcd(g, P) == 1]
+
+
+def character_value(g, exponents):
+    """Character on (Z/210Z)^x via CRT factors 2,3,5,7.
+
+    The factors have unit-group sizes 1,2,4,6. We use primitive roots for
+    3,5,7 and the trivial factor for 2.
+    """
+    _, e3, e5, e7 = exponents
+
+    idx3 = 0 if g % 3 == 1 else 1
+
+    powers5 = {1: 0, 2: 1, 4: 2, 3: 3}
+    idx5 = powers5[g % 5]
+
+    powers7 = {1: 0, 3: 1, 2: 2, 6: 3, 4: 4, 5: 5}
+    idx7 = powers7[g % 7]
+
+    return (
+        cmath.exp(2j * math.pi * e3 * idx3 / 2)
+        * cmath.exp(2j * math.pi * e5 * idx5 / 4)
+        * cmath.exp(2j * math.pi * e7 * idx7 / 6)
+    )
+
+
+def all_character_exponents():
+    return [(0, e3, e5, e7) for e3 in range(2) for e5 in range(4) for e7 in range(6)]
+
+
+def raw_character_sum(exponents, B):
+    total = 0j
+    for p in primes_upto(B):
+        if gcd(p, P4) == 1:
+            total += log(p) * character_value(p, exponents)
+    return total
+
+
+def gaussian_eigenvalue(exponents, sigma, B):
+    total = 0j
+    for p in primes_upto(B):
+        if gcd(p, P4) == 1:
+            weight = math.exp(-(log(p) ** 2) / (2 * sigma**2))
+            total += log(p) * character_value(p, exponents) * weight
+    return total
+
+
+def symmetric_eigenvalue(exponents):
+    total = 0.0
+    for p in PRIMES_MODULUS:
+        if gcd(p, P4) == 1:
+            total += log(p) * character_value(p, exponents).real
+    return total
+
+
+def fourier_transform(h, exponents):
+    group = units_mod(P4)
+    return sum(h[g] * character_value(g, exponents).conjugate() for g in group)
+
+
+def finite_weil_positive_distribution(h):
+    group = units_mod(P4)
+    total = 0.0
+    for exponents in all_character_exponents():
+        h_hat = fourier_transform(h, exponents)
+        lam = symmetric_eigenvalue(exponents)
+        total += abs(h_hat) ** 2 * abs(lam) ** 2
+    return total / len(group)
+
+
+def test_character_count_for_p4_is_phi_210():
+    group = units_mod(P4)
+    assert len(group) == 48
+    assert len(all_character_exponents()) == 48
+
+
+def test_raw_symmetric_spectrum_has_negative_values():
+    values = [symmetric_eigenvalue(exponents) for exponents in all_character_exponents()]
+    assert min(values) < 0
+    assert max(values) > 0
+
+
+def test_squared_spectrum_is_nonnegative_for_all_48_characters():
+    for exponents in all_character_exponents():
+        lam = symmetric_eigenvalue(exponents)
+        assert abs(lam) ** 2 >= 0
+
+
+def test_finite_weil_distribution_positive_for_delta_functions():
+    group = units_mod(P4)
+    for point in group[:10]:
+        h = {g: 1.0 if g == point else 0.0 for g in group}
+        assert finite_weil_positive_distribution(h) >= 0
+
+
+def test_finite_weil_distribution_positive_for_structured_function():
+    group = units_mod(P4)
+    h = {g: float((g % 11) - 5) for g in group}
+    assert finite_weil_positive_distribution(h) >= 0
+
+
+def test_finite_weil_distribution_zero_for_zero_function():
+    group = units_mod(P4)
+    h = {g: 0.0 for g in group}
+    assert finite_weil_positive_distribution(h) == 0.0
+
+
+def test_gaussian_eigenvalues_nonzero():
+    for B in [200, 500]:
+        sigma = log(B) / 2
+        for exponents in all_character_exponents():
+            assert abs(gaussian_eigenvalue(exponents, sigma, B)) > 0
+
+
+def test_gaussian_finite_weil_distribution_positive():
+    for B in [200, 500, 1000]:
+        sigma = log(B) / 2
+        lams = [gaussian_eigenvalue(exponents, sigma, B) for exponents in all_character_exponents()]
+        W = sum(abs(lam) ** 2 for lam in lams) / 48
+        assert W > 0
+
+
+def test_grh_signature_ratio_bounded():
+    B = 500
+    for exponents in all_character_exponents():
+        psi = raw_character_sum(exponents, B)
+        assert abs(psi) / sqrt(B) < log(B) ** 2
+
+
+def test_short_window_growth_ratio_is_not_used_as_a_gate():
+    # Individual moderate-scale character ratios are oscillatory. The test records
+    # that the robust finite gate is the GRH-signature envelope, not a two-point
+    # B=200 to B=500 ratio bound.
+    B = 500
+    ratios = [abs(raw_character_sum(exponents, B)) / sqrt(B) for exponents in all_character_exponents()]
+    assert max(ratios) < log(B) ** 2


### PR DESCRIPTION
## Summary

Adds `HW-PRIME-WEIL-001`, documenting the finite Weil positivity approach and its conditional convergence boundary.

Files:

- `docs/prime-operator-lane/weil-positivity-approach.md`
- `tests/test_weil_positivity.py`

## Scope

Documentation/tests only. Finite positivity theorem plus conditional target framing. No RH/GRH proof, no Hilbert-Polya construction, no essential-self-adjointness claim, and no finite-to-Weil propagation theorem.