### PR TITLE
docs: add polynomial orbit and prime residue oracle

### DIFF
--- a/docs/prime-operator-lane/open-problems-register.md
+++ b/docs/prime-operator-lane/open-problems-register.md
@@ -187,6 +187,29 @@ Open: formalize this base hierarchy as a typed bridge connecting the finite arit
 
 Non-claim: this entry does not assert that any base yields a proof of RH, GRH, or Yang-Mills mass gap. It records natural coordinate systems for each level and the open bridge problem between them.
 
+## HW-OPEN-007 — Prime residue oracle and repeating-decimal sieve
+
+Finite scaffolding:
+
+- `HW-PRIME-WINDOW-001`
+- `HW-PRIME-FINITE-OPERATOR-001`
+- `HW-PRIME-WEIL-001`
+- `HW-PRIME-WEIL-002`
+
+Problem: formalize the digit-cycle / residue-class oracle that connects repeating decimal structure, repunit resonances, and prime-window residue transitions.
+
+The candidate oracle surface has three finite components:
+
+1. a repeating-decimal sieve, where the cycle of `1/q` identifies residue-period information through `ord_q(10)`;
+2. a first-digit / terminal-digit admissibility bound, where base-10 prime candidates are restricted to `{1,3,7,9}` at the terminal digit, giving the `2/5` admissibility density among digits `0..9`;
+3. a residue-transition oracle, where the next-prime candidate transition is constrained by the current residue class, the repunit resonance cycle, and the finite character orbit.
+
+The polynomial orbit analysis from `HW-PRIME-WINDOW-001` is a test surface for this oracle. For `n^2+1`, the orbit in `G_210` has size `16` out of `48`; all even-`n` prime candidates are `1 mod 4`; primes `3 mod 4` never divide values of `n^2+1`; and the gap sequence between even-`n` candidates is an arithmetic progression with common difference `8`.
+
+Open: determine whether the oracle is merely a finite sieve description or whether it yields a reusable bound on Richter-window character sums for polynomial thin sets.
+
+Non-claim: this entry does not predict the next prime, prove infinitude of primes of the form `n^2+1`, prove Landau's fourth problem, prove RH/GRH, or construct a Hilbert-Pólya operator.
+
 ## Register non-claim
 
 This register does not assert progress toward any Clay problem. It records open problems, current scaffolding, and the precise finite/infinite boundary of the prime/operator-lane program.

--- a/docs/prime-operator-lane/prime-window-repunit-diagnostic.md
+++ b/docs/prime-operator-lane/prime-window-repunit-diagnostic.md
@@ -269,7 +269,71 @@ The half-step `1/2` in this logarithmic center is the same normalization scale t
 
 The density of first digits admissible to primes in base 10 is `2/5`: among digits `1..9`, the terminal-prime-compatible odd non-5 digits are `{1,3,7,9}`. This is the terminal-digit admissibility density, not the full prime density in a window.
 
-## 8. Euler-Mascheroni correction per window
+## 8. Taylor, theta, and half-integer split diagnostics
+
+The Taylor series split
+
+```text
+exp(x) = sum_{n even} x^n/n! + sum_{n odd} x^n/n!
+```
+
+separates the even and odd streams. With imaginary argument,
+
+```text
+exp(i x) = cos(x) + i sin(x),
+```
+
+where `cos(x)` uses even powers and `sin(x)` uses odd powers. This is an exact parity decomposition of the exponential series.
+
+The polynomial generating series
+
+```text
+sum_{n>=0} z^(n^k+p) = z^p sum_{n>=0} z^(n^k)
+```
+
+has the same parity split:
+
+```text
+z^p (sum_m z^((2m)^k) + sum_m z^((2m+1)^k)).
+```
+
+For `k=2`, this is a theta-function split. The full bilateral theta series is
+
+```text
+theta_3(q) = sum_{n in Z} q^(n^2),
+```
+
+and the even-square part is governed by `theta_3(q^4)`. Thus the parity split of `n^2+p` is the arithmetic version of the even/odd split of the theta series.
+
+The tangent ratio records the corresponding analytic split:
+
+```text
+tan(x) = sin(x)/cos(x),
+tanh(x) = sinh(x)/cosh(x).
+```
+
+This is a structural diagnostic only. It does not assert that ratios of prime counts literally converge to a tangent function.
+
+The Mittag-Leffler identity
+
+```text
+sum_{n=1}^infinity 1/(n^2+1)
+  = (pi coth(pi) - 1)/2
+```
+
+is a concrete bridge from the `n^2+1` denominator sequence to the trigonometric / hyperbolic meromorphic structure. It records the same `i`-root structure because `n^2+1=(n-i)(n+i)`.
+
+The poles of `tan(z)` occur at
+
+```text
+z = pi(k+1/2),
+```
+
+which exposes the half-integer shift in the trigonometric decomposition. This `1/2` also appears in the Richter geometric center `10^(k-1/2)` and in the critical-line coordinate `Re(s)=1/2`. The shared value is a coordinate/fixed-point diagnostic, not by itself a proof of RH.
+
+The theta functional equation is the rigorous analytic bridge from theta parity structure to zeta functional-equation symmetry. This document records the finite diagnostic connection only; it does not claim that the finite window split forces zero locations.
+
+## 9. Euler-Mascheroni correction per window
 
 The Euler-Mascheroni constant records the leading residual between discrete harmonic sums and their continuous logarithmic approximation:
 
@@ -295,7 +359,7 @@ is the depth-3 fingerprint of this structure: additive repunit stacking, triangu
 
 This is a diagnostic finite-arithmetic statement. It does not assert that `gamma` alone predicts prime counts in digit windows.
 
-## 9. Boundary with HW-PRIME-FINITE-OPERATOR-001
+## 10. Boundary with HW-PRIME-FINITE-OPERATOR-001
 
 `HW-PRIME-FINITE-OPERATOR-001` defines the full finite character-operator diagnostic over a selected modulus and prime cutoff.
 
@@ -303,7 +367,7 @@ The window operator `T_hat_{W_k}` is a restriction of that finite operator to a 
 
 Thus `HW-PRIME-WINDOW-001` does not replace `HW-PRIME-FINITE-OPERATOR-001`. It refines it by adding digit-window localization and repunit-resonance diagnostics.
 
-## 10. Ehrhart polynomial — discrete side of zeta
+## 11. Ehrhart polynomial — discrete side of zeta
 
 The Ehrhart polynomial of a lattice polytope `P` counts lattice points in dilates:
 
@@ -382,5 +446,7 @@ This document does not prove RH, GRH, Hilbert-Pólya, or any zero-location theor
 This document does not claim that digital-root cycles determine primality.
 
 This document does not assert that polynomial orbit density proves primality or gives an asymptotic formula for polynomial prime values.
+
+This document does not assert that the Taylor/theta parity split proves a zeta zero-location theorem.
 
 This document does not assert proof transfer to Yang-Mills or any Clay problem.

--- a/docs/prime-operator-lane/prime-window-repunit-diagnostic.md
+++ b/docs/prime-operator-lane/prime-window-repunit-diagnostic.md
@@ -192,7 +192,84 @@ lambda_chi(W_k) = sum_{g in G_{P_k}} A_{W_k}(g) chi(g).
 
 These window eigenvalues approximate the character-sum behavior of primes restricted to `W_k`.
 
-## 6. Euler-Mascheroni correction per window
+## 6. Polynomial value distributions
+
+For fixed `k` and fixed odd `p`, the polynomial value sequence
+
+```text
+n^k + p
+```
+
+splits into two parity streams:
+
+```text
+E_k = {n^k + p : n even},
+O_k = {n^k + p : n odd}.
+```
+
+For odd `p`, the even-`n` stream is odd and contains the only ordinary prime candidates beyond the exceptional prime `2`; the odd-`n` stream is even and therefore composite except in trivial edge cases.
+
+For `n^2+1`, the prime-candidate stream is obtained from even `n`. It has values
+
+```text
+(2m)^2 + 1 = 4m^2 + 1,
+```
+
+so every candidate is congruent to `1 mod 4`. The gaps between consecutive even-`n` candidates are
+
+```text
+(2m+2)^2 + 1 - ((2m)^2 + 1) = 8m + 4,
+```
+
+an arithmetic progression with common difference `8`. All gaps are divisible by `4`.
+
+Modulo `G_210=(Z/210Z)^x`, the orbit
+
+```text
+{n^2+1 mod 210 : gcd(n^2+1,210)=1}
+```
+
+has size `16`, exactly one third of the 48 unit classes. Thus the polynomial value stream reaches a strict subset of the finite prime residue surface.
+
+This gives a finite orbit-density diagnostic: polynomial thin sets occupy only the residue classes admitted by their modular orbit. It is an upper-bound and sieve diagnostic, not a prime-count theorem.
+
+For primes `q == 3 mod 4`, `-1` is not a quadratic residue modulo `q`, so
+
+```text
+n^2 + 1 != 0 mod q
+```
+
+for all `n`. Equivalently, such primes never divide a value of `n^2+1`. The sequence is therefore permanently sieved away from those divisor classes.
+
+More generally, `n^2+p == 0 mod q` is possible exactly when `-p` is a quadratic residue modulo `q`, except at the degenerate local factors dividing `2pq`. This quadratic-residue criterion is the local sieve law for the polynomial value distribution.
+
+## 7. Perfect cancellation and geometric window center
+
+On any finite group `G`, every non-trivial character satisfies
+
+```text
+sum_{g in G} chi(g) = 0.
+```
+
+For `G_10=(Z/10Z)^x={1,3,7,9}`, this is the perfect cancellation theorem for non-trivial characters modulo 10. It is finite coset orthogonality and does not depend on prime distribution.
+
+The Richter window
+
+```text
+[10^(k-1), 10^k)
+```
+
+has geometric center
+
+```text
+sqrt(10^(k-1) * 10^k) = 10^(k-1/2).
+```
+
+The half-step `1/2` in this logarithmic center is the same normalization scale that appears in GRH-compatible Richter growth. This is a coordinate identity, not a proof of GRH.
+
+The density of first digits admissible to primes in base 10 is `2/5`: among digits `1..9`, the terminal-prime-compatible odd non-5 digits are `{1,3,7,9}`. This is the terminal-digit admissibility density, not the full prime density in a window.
+
+## 8. Euler-Mascheroni correction per window
 
 The Euler-Mascheroni constant records the leading residual between discrete harmonic sums and their continuous logarithmic approximation:
 
@@ -218,7 +295,7 @@ is the depth-3 fingerprint of this structure: additive repunit stacking, triangu
 
 This is a diagnostic finite-arithmetic statement. It does not assert that `gamma` alone predicts prime counts in digit windows.
 
-## 7. Boundary with HW-PRIME-FINITE-OPERATOR-001
+## 9. Boundary with HW-PRIME-FINITE-OPERATOR-001
 
 `HW-PRIME-FINITE-OPERATOR-001` defines the full finite character-operator diagnostic over a selected modulus and prime cutoff.
 
@@ -226,7 +303,7 @@ The window operator `T_hat_{W_k}` is a restriction of that finite operator to a 
 
 Thus `HW-PRIME-WINDOW-001` does not replace `HW-PRIME-FINITE-OPERATOR-001`. It refines it by adding digit-window localization and repunit-resonance diagnostics.
 
-## 8. Ehrhart polynomial — discrete side of zeta
+## 10. Ehrhart polynomial — discrete side of zeta
 
 The Ehrhart polynomial of a lattice polytope `P` counts lattice points in dilates:
 
@@ -303,5 +380,7 @@ This document does not prove a prime number theorem in windows.
 This document does not prove RH, GRH, Hilbert-Pólya, or any zero-location theorem.
 
 This document does not claim that digital-root cycles determine primality.
+
+This document does not assert that polynomial orbit density proves primality or gives an asymptotic formula for polynomial prime values.
 
 This document does not assert proof transfer to Yang-Mills or any Clay problem.

--- a/docs/prime-operator-lane/weil-growth-rate-theorem.md
+++ b/docs/prime-operator-lane/weil-growth-rate-theorem.md
@@ -98,7 +98,143 @@ The reverse implication is the contrapositive: if any zero satisfies `Re(rho)>1/
 
 This is a characterization surface, not a proof that the polynomial bound holds.
 
-## 4. Fake-zero diagnostic
+## 4. Hyperbolic cancellation and wave-front theorem surface
+
+Write an off-line zero as
+
+```text
+rho = 1/2 + delta + i gamma.
+```
+
+Then
+
+```text
+x^rho = x^(1/2) x^delta exp(i gamma log x).
+```
+
+Using
+
+```text
+x^delta = cosh(delta log x) + sinh(delta log x),
+```
+
+the contribution decomposes into an even hyperbolic envelope and an odd hyperbolic envelope.
+
+On the critical line, `delta=0`, and therefore
+
+```text
+sinh(0)=0,
+cosh(0)=1,
+cosh(0)^2 - sinh(0)^2 = 1.
+```
+
+Thus the odd envelope vanishes exactly. The zero-pair contribution is a pure oscillation at the `x^(1/2)` envelope scale:
+
+```text
+Delta_rho(x) = x^rho/rho + x^conjugate(rho)/conjugate(rho)
+             = 2 x^(1/2) cos(gamma log x - arg(rho)) / |rho|.
+```
+
+Off the critical line, `delta>0`, both `cosh(delta log x)` and `sinh(delta log x)` grow at scale `x^delta`. The identity
+
+```text
+cosh(u)^2 - sinh(u)^2 = 1
+```
+
+still holds, but the individual envelopes are large. This is the algebraic certificate of broken cancellation: the difference remains fixed while the sum of envelopes grows.
+
+The Richter-normalized off-line envelope has asymptotic scale
+
+```text
+4 cosh(delta k log 10)^2 / k^2 ~ 10^(2 delta k) / k^2.
+```
+
+This records the algebraic mechanism. It does not by itself prove that every possible off-line zero configuration escapes cancellation in the linear character sum.
+
+## 5. Tanh as Richter deviation meter
+
+The ratio
+
+```text
+tanh(delta log x) = sinh(delta log x) / cosh(delta log x)
+                  = (x^delta - x^(-delta)) / (x^delta + x^(-delta))
+```
+
+is a deviation meter for the odd envelope.
+
+At `delta=0`, `tanh(0)=0`: the odd envelope is absent. For fixed `delta>0`, `tanh(delta log x) -> 1` as `x -> infinity`: the odd and even hyperbolic envelopes become comparable, and the off-line growth becomes visible.
+
+Diagnostic values for `u=delta k log 10`:
+
+| `delta` | `k=2` | `k=3` | `k=5` | `k=10` |
+| ---: | ---: | ---: | ---: | ---: |
+| `0` | `0` | `0` | `0` | `0` |
+| `0.05` | `0.226` | `0.332` | `0.520` | `0.818` |
+| `0.10` | `0.430` | `0.598` | `0.818` | `0.980` |
+| `0.20` | `0.726` | `0.881` | `0.980` | `0.9998` |
+
+The related envelope-excess quantity
+
+```text
+cosh(delta k log 10)^2 - 1
+```
+
+is exactly zero at `delta=0` and grows rapidly for `delta>0`.
+
+## 6. Theta functional equation source
+
+The Jacobi theta function
+
+```text
+theta_3(q) = sum_{n in Z} q^(n^2)
+```
+
+splits into even and odd square streams. Its functional equation
+
+```text
+theta_3(exp(-pi t)) = t^(-1/2) theta_3(exp(-pi/t))
+```
+
+has self-dual point `t=1`. Under Mellin transform, this self-duality is the source of the zeta functional equation
+
+```text
+xi(s) = xi(1-s),
+```
+
+whose fixed line is `Re(s)=1/2`.
+
+This is the analytic source of the repeated half-step appearing in the Richter geometric center `10^(k-1/2)`, the tangent pole shift `pi(k+1/2)`, and the critical-line coordinate. The shared half-step is a structural diagnostic; it is not a standalone zero-location proof.
+
+## 7. Parseval bias opening
+
+For a finite modulus group `G_P`, define the residue-window weights
+
+```text
+f_k(g) = sum_{p in W_k, p mod P = g} log p.
+```
+
+Finite Parseval gives
+
+```text
+(1/|G_P|) sum_chi |psi_{W_k}(chi)|^2 = sum_g f_k(g)^2.
+```
+
+The trivial character records the total mass. The non-trivial characters record the excess second moment: the amount by which the window distribution across residue classes deviates from perfect equidistribution.
+
+This is the promising cancellation-avoidance surface. Linear character sums can hide phase cancellation. The Parseval second moment is a sum of absolute squares, so it is intrinsically non-negative. An off-line zero, if it forces a persistent bias in one or more residue classes, should appear as growth in this real second-moment excess.
+
+Target estimate:
+
+```text
+if L(s,chi) has a zero at 1/2 + delta + i gamma with delta>0,
+then sum_g f_k(g)^2 has an Omega(10^((1+2 delta)k)/k^2) excess component
+```
+
+in the corresponding windows, after subtracting the trivial-character baseline and controlling lower-order terms.
+
+This is not proved here. The missing proof obligation is the explicit-formula estimate that transfers off-line zero growth into the Parseval-bias excess without allowing cancellation across the character family.
+
+## 8. Fake-zero diagnostic
 
 For a hypothetical off-line zero
 
@@ -123,7 +259,7 @@ up to oscillatory factors.
 
 This fake-zero diagnostic is not evidence for the existence of an off-line zero. It is a falsifiability harness for the framework: a correct Richter-window model must distinguish GRH-scale behavior from off-line exponential growth.
 
-## 5. Numerical evidence boundary
+## 9. Numerical evidence boundary
 
 At the current measured scales for the `P=210` family, the normalized Richter ratios are small and decreasing for the tested character `chi_(1,1,1)`:
 
@@ -141,7 +277,7 @@ k=3: ~= 0.64
 
 This is finite evidence consistent with GRH-scale behavior. It is not a proof and it does not establish the asymptotic polynomial bound.
 
-## 6. Relation to `HW-OPEN-001`
+## 10. Relation to `HW-OPEN-001`
 
 `HW-OPEN-001` originally framed the central gap as a Hilbert-Polya finite extension. `HW-PRIME-WEIL-002` records a second route: a growth-rate characterization of the same hard spectral boundary using explicitly computable prime-window sums.
 
@@ -157,11 +293,13 @@ GRH-strength statement.
 
 The value of this formulation is operational: it is computable from primes, window-local, and CI-testable at finite depth.
 
-## 7. Non-claims
+## 11. Non-claims
 
 This document does not prove RH or GRH.
 
 This document does not prove the polynomial growth bound.
+
+This document does not prove the Parseval-bias lower bound for off-line zeros.
 
 This document does not prove that finite positivity propagates to the full Weil distribution.
 

--- a/tests/test_prime_window_polynomial_orbits.py
+++ b/tests/test_prime_window_polynomial_orbits.py
@@ -1,8 +1,12 @@
-from math import cos, coth, factorial, gcd, pi, sqrt, tan
+from math import cos, cosh, exp, factorial, gcd, log, pi, sinh, sqrt, tan, tanh
 
 
 def repunit(k):
     return (10**k - 1) // 9
+
+
+def theta3(q, terms=20):
+    return 1 + 2 * sum(q ** (n**2) for n in range(1, terms))
 
 
 def test_n_squared_plus_1_orbit_in_G210():
@@ -92,7 +96,38 @@ def test_tan_poles_at_half_integer_pi():
 
 
 def test_mittag_leffler_sum_n_squared_plus_1():
-    n_max = 1000
+    n_max = 10000
     partial = sum(1 / (n**2 + 1) for n in range(1, n_max + 1))
-    full = pi * coth(pi) / 2 - 1 / 2
-    assert abs(partial - full) < 0.01
+    exact = (pi / tanh(pi) - 1) / 2
+    assert abs(partial - exact) < 0.001
+
+
+def test_exact_cancellation_on_critical_line():
+    assert sinh(0) == 0.0
+    assert cosh(0) == 1.0
+    assert cosh(0) ** 2 - sinh(0) ** 2 == 1.0
+
+
+def test_hyperbolic_identity_holds_exactly():
+    for delta in [0, 0.1, 0.5, 1.0, 2.0]:
+        for k in [1, 2, 3, 5, 10]:
+            u = delta * k * log(10)
+            assert abs(cosh(u) ** 2 - sinh(u) ** 2 - 1.0) < 1e-9
+
+
+def test_tanh_is_zero_on_critical_line():
+    assert tanh(0) == 0.0
+
+
+def test_tanh_approaches_one_off_critical_line():
+    for delta in [0.1, 0.2]:
+        for k in [10, 20]:
+            u = delta * k * log(10)
+            assert tanh(u) > 0.9
+
+
+def test_theta_functional_equation_at_t_equals_1():
+    t = 1.0
+    lhs = theta3(exp(-pi * t))
+    rhs = t ** (-0.5) * theta3(exp(-pi / t))
+    assert abs(lhs - rhs) < 1e-6

--- a/tests/test_prime_window_polynomial_orbits.py
+++ b/tests/test_prime_window_polynomial_orbits.py
@@ -1,0 +1,71 @@
+from math import gcd, sqrt
+
+
+def repunit(k):
+    return (10**k - 1) // 9
+
+
+def test_n_squared_plus_1_orbit_in_G210():
+    orbit = {(n**2 + 1) % 210 for n in range(210) if gcd((n**2 + 1) % 210, 210) == 1}
+    assert len(orbit) == 16
+
+
+def test_prime_candidates_all_equiv_1_mod_4():
+    for n in range(0, 100, 2):
+        assert (n**2 + 1) % 4 == 1
+
+
+def test_even_odd_split_for_odd_p():
+    for k in [2, 3]:
+        for p in [1, 3, 5]:
+            for n in range(10):
+                value = n**k + p
+                if n % 2 == 0:
+                    assert value % 2 == 1
+                else:
+                    assert value % 2 == 0
+
+
+def test_gap_sequence_is_arithmetic_progression():
+    values = [n**2 + 1 for n in range(0, 20, 2)]
+    gaps = [values[i + 1] - values[i] for i in range(len(values) - 1)]
+    diffs = [gaps[i + 1] - gaps[i] for i in range(len(gaps) - 1)]
+    assert all(diff == 8 for diff in diffs)
+
+
+def test_primes_equiv_3_mod_4_never_divide_n_squared_plus_1():
+    for p in [3, 7, 11, 19, 23, 31]:
+        assert p % 4 == 3
+        assert all((n**2 + 1) % p != 0 for n in range(p))
+
+
+def test_perfect_cancellation_on_mod10_cosets():
+    units = [1, 3, 7, 9]
+    nontrivial_character = {1: 1, 3: -1, 7: -1, 9: 1}
+    assert sum(nontrivial_character[g] for g in units) == 0
+
+
+def test_geometric_center_of_richter_window():
+    for k in range(1, 6):
+        low = 10 ** (k - 1)
+        high = 10**k
+        assert sqrt(low * high) == 10 ** (k - 0.5)
+
+
+def test_admissible_density_is_two_fifths():
+    admissible_terminal_digits = {1, 3, 7, 9}
+    assert len(admissible_terminal_digits) / 10 == 2 / 5
+
+
+def test_next_prime_transition_from_3_most_likely_7():
+    # Finite toy oracle: after terminal digit 3, adding 4 reaches 7, the next
+    # admissible terminal class before wraparound to 1.
+    admissible_cycle = [1, 3, 7, 9]
+    idx = admissible_cycle.index(3)
+    assert admissible_cycle[idx + 1] == 7
+    assert (3 + 4) % 10 == 7
+
+
+def test_repunit_resonance_prime_11_in_depth_2():
+    assert repunit(2) == 11
+    assert repunit(2) % 11 == 0

--- a/tests/test_prime_window_polynomial_orbits.py
+++ b/tests/test_prime_window_polynomial_orbits.py
@@ -85,7 +85,7 @@ def test_even_stream_generates_theta_function():
     z = 0.1
     even_stream = sum(z ** (4 * m**2) for m in range(10))
     theta_approx = 1 + 2 * sum(z ** (4 * m**2) for m in range(1, 10))
-    assert abs(even_stream - theta_approx + 1) < 1e-12
+    assert abs(2 * even_stream - theta_approx - 1) < 1e-10
 
 
 def test_tan_poles_at_half_integer_pi():

--- a/tests/test_prime_window_polynomial_orbits.py
+++ b/tests/test_prime_window_polynomial_orbits.py
@@ -1,4 +1,4 @@
-from math import gcd, sqrt
+from math import cos, coth, factorial, gcd, pi, sqrt, tan
 
 
 def repunit(k):
@@ -69,3 +69,30 @@ def test_next_prime_transition_from_3_most_likely_7():
 def test_repunit_resonance_prime_11_in_depth_2():
     assert repunit(2) == 11
     assert repunit(2) % 11 == 0
+
+
+def test_cosine_series_uses_even_powers_only():
+    x = 0.5
+    cos_approx = sum((-1) ** n * x ** (2 * n) / factorial(2 * n) for n in range(10))
+    assert abs(cos_approx - cos(x)) < 1e-10
+
+
+def test_even_stream_generates_theta_function():
+    z = 0.1
+    even_stream = sum(z ** (4 * m**2) for m in range(10))
+    theta_approx = 1 + 2 * sum(z ** (4 * m**2) for m in range(1, 10))
+    assert abs(even_stream - theta_approx + 1) < 1e-12
+
+
+def test_tan_poles_at_half_integer_pi():
+    for k in range(5):
+        pole = pi * (k + 0.5)
+        x_near = pole - 0.001
+        assert abs(tan(x_near)) > 100
+
+
+def test_mittag_leffler_sum_n_squared_plus_1():
+    n_max = 1000
+    partial = sum(1 / (n**2 + 1) for n in range(1, n_max + 1))
+    full = pi * coth(pi) / 2 - 1 / 2
+    assert abs(partial - full) < 0.01


### PR DESCRIPTION
## Summary

Adds polynomial value orbit diagnostics to `HW-PRIME-WINDOW-001`, adds `HW-OPEN-007` for the prime residue oracle / repeating-decimal sieve, and adds finite tests for polynomial orbits, perfect cancellation, geometric window center, and terminal-digit admissibility.

Files:

- `docs/prime-operator-lane/prime-window-repunit-diagnostic.md`
- `docs/prime-operator-lane/open-problems-register.md`
- `tests/test_prime_window_polynomial_orbits.py`

## Scope

Finite arithmetic diagnostics only. Records parity splitting, `n^2+1` orbit size in `G_210`, gap arithmetic, quadratic-residue sieve law, mod-10 cancellation, Richter geometric center, and terminal-digit admissibility. No next-prime prediction, no Landau-fourth proof, no RH/GRH proof, and no Hilbert-Polya construction.