### PR TITLE
prime-weil: add HW-OPEN-009 windowed Omega target

### DIFF
--- a/docs/prime-operator-lane/HW-OPEN-009-windowed-omega-register-note.md
+++ b/docs/prime-operator-lane/HW-OPEN-009-windowed-omega-register-note.md
@@ -1,0 +1,53 @@
+# HW-OPEN-009 — Windowed Omega Theorem Register Note
+
+Status: companion open-problem register note.  
+Claim class: open analytic theorem target.  
+Canonical target document: `docs/prime-operator-lane/windowed-omega-theorem-target.md`.
+
+## Problem
+
+Prove a windowed Omega theorem for Richter-window character sums.
+
+If `L(s, chi)` has an off-critical zero:
+
+```text
+rho_0 = sigma_0 + i t_0,    sigma_0 > 1/2,
+```
+
+then prove that there are infinitely many Richter-window depths `K`, preferably a positive-density subsequence, such that:
+
+```text
+|psi_{W_K}(chi)| >= c 10^(K sigma_0)
+```
+
+for some `c > 0`.
+
+## Relationship to HW-PRIME-WEIL-005
+
+`HW-PRIME-WEIL-005` identifies the square-root barrier for the fixed-modulus Parseval variance route.
+
+`HW-OPEN-009` isolates the lower-bound side of that route. It does not supply the missing unconditional critical-scale variance upper bound.
+
+## Path A — direct phase route
+
+Directly analyze the exponential-polynomial zero sum in the Richter windows. This route may require almost-periodicity or rational-independence control for zero ordinates.
+
+Status: open.
+
+## Path B — Cesaro / second-moment route
+
+Use the normalized second moment over window depth. The diagonal contribution of the selected zero supplies a positive candidate contribution.
+
+Status: promising partial route. The diagonal calculation is not by itself a complete proof. The remaining obligations are cross-term control, truncation control, same-real-part zero handling, and explicit-formula error control.
+
+## Non-claims
+
+This note does not prove RH.
+
+This note does not prove GRH.
+
+This note does not prove the windowed Omega theorem.
+
+This note does not prove the unconditional variance bound.
+
+This note does not close `HW-PRIME-WEIL-004` or `HW-PRIME-WEIL-005`.

--- a/docs/prime-operator-lane/windowed-omega-theorem-target.md
+++ b/docs/prime-operator-lane/windowed-omega-theorem-target.md
@@ -1,0 +1,183 @@
+# HW-OPEN-009 — Windowed Omega Theorem Target
+
+Status: proof-target document.  
+Claim class: open analytic theorem target / partial diagonal-moment route.  
+Lane: prime/operator lane, fixed-modulus Richter-window variance route.  
+Depends on: `HW-PRIME-WEIL-004`, `HW-PRIME-WEIL-005`, finite Parseval variance identity.
+
+## Purpose
+
+This document isolates the missing analytic input identified by `HW-PRIME-WEIL-004` and `HW-PRIME-WEIL-005`:
+
+```text
+windowed Omega behavior for Richter-window character sums.
+```
+
+The target is narrower than an unconditional variance bound and separable from the square-root-barrier question.
+
+## Target statement
+
+Let `chi` be a nontrivial Dirichlet character and suppose `L(s, chi)` has a zero:
+
+```text
+rho_0 = sigma_0 + i t_0,    sigma_0 > 1/2.
+```
+
+For Richter windows `W_K`, define:
+
+```text
+psi_{W_K}(chi)
+```
+
+as the Chebyshev-weighted character sum over the decimal digit-depth window.
+
+The target is a subsequence/windowed Omega statement:
+
+```text
+|psi_{W_K}(chi)| >= c 10^(K sigma_0)
+```
+
+for infinitely many `K`, or preferably for a positive-density subsequence of `K`, with `c>0` depending on the character and the zero data.
+
+This is weaker than pointwise dominance for all large `K` and is the correct input needed by the fixed-modulus Parseval variance route.
+
+## Why this is the right target
+
+`HW-PRIME-WEIL-005` records that the variance route needs an off-line-zero lower bound along the Richter windows.
+
+The classical cumulative Omega theorem says that an off-line zero forces large oscillations in cumulative prime sums. The current obstacle is transferring that information to the fixed decimal/Richter window family.
+
+The windowed Omega theorem is exactly this transfer.
+
+## Explicit-formula window term
+
+The Richter-window explicit formula has the model form:
+
+```text
+psi_{W_K}(chi)
+  = sum_rho A_K(rho) + error_K
+```
+
+with:
+
+```text
+A_K(rho) = 10^((K-1)rho) (10^rho - 1) / rho.
+```
+
+For the selected off-line zero `rho_0`:
+
+```text
+|A_K(rho_0)| = C_0 10^(K sigma_0)
+```
+
+where:
+
+```text
+C_0 = 10^(-sigma_0) |10^rho_0 - 1| / |rho_0| > 0.
+```
+
+The goal is not to prove that this single term dominates pointwise for every `K`. The goal is to prove that the full window sum has Omega-size along sufficiently many windows.
+
+## Path A — Direct phase route
+
+The direct route studies the exponential polynomial formed by the zero terms:
+
+```text
+sum_rho c_rho 10^(K rho)
+```
+
+and attempts to show non-cancellation for infinitely many `K`.
+
+This route can depend on phase properties of zero ordinates, such as rational independence or almost-periodicity arguments.
+
+Status: open. This route is not needed if Path B succeeds.
+
+## Path B — Cesaro / second-moment route
+
+The promising route is to average the squared normalized window sum over `K`.
+
+A target normalized second moment is:
+
+```text
+(1/N) sum_{K=1}^N |psi_{W_K}(chi)|^2 / 10^(2K sigma_0).
+```
+
+The diagonal contribution from `rho_0` is positive and has a geometric-series normalization. In the single-zero model, it gives a positive limiting lower contribution of the form:
+
+```text
+C_0^2 * positive_geometric_factor.
+```
+
+Therefore, in the single-dominant-zero model, the normalized second moment has positive lower density and implies:
+
+```text
+|psi_{W_K}(chi)| >= c 10^(K sigma_0)
+```
+
+for a positive-density subsequence of windows.
+
+## What Path B still owes
+
+The diagonal term is the correct spine, but theorem-grade promotion requires controlling the full mean square, not only writing the diagonal contribution.
+
+Open obligations:
+
+1. State the exact truncated/windowed explicit formula with error term.
+2. Choose the zero set included in the second moment and justify truncation.
+3. Prove that lower-real-part zeros are negligible after normalization.
+4. Handle zeros with the same real part as `rho_0`, including conjugates and multiplicities.
+5. Control off-diagonal cross terms in the Cesaro mean or prove a positive lower bound for the resulting exponential-polynomial mean square.
+6. Show the explicit-formula error does not cancel the zero contribution at the normalized mean-square level.
+7. Convert positive normalized second moment into an infinite or positive-density subsequence lower bound.
+
+The key advantage of Path B is that it does not require pointwise phase control for every `K` and should not require irrationality assumptions if the mean-square lower bound is established directly.
+
+## Relation to the variance route
+
+If the windowed Omega theorem is proved, then an off-line zero gives:
+
+```text
+|psi_{W_K}(chi)| >= c 10^(K sigma_0)
+```
+
+along infinitely many windows. Parseval then gives:
+
+```text
+Var_P(W_K) >= (c^2 / |G_P|) 10^(2K sigma_0)
+```
+
+along that subsequence.
+
+Combined with a hypothetical unconditional critical-scale variance bound:
+
+```text
+Var_P(W_K) = O_P(10^K K^A),
+```
+
+this would contradict `sigma_0 > 1/2`.
+
+Thus this theorem target discharges the lower-bound side of the variance route. It does not by itself supply the missing unconditional upper bound.
+
+## Status of the main barrier
+
+`HW-PRIME-WEIL-005` remains the controlling barrier map.
+
+Even if `HW-OPEN-009` is proved, the GRH proof still needs an unconditional critical-scale variance upper bound or another non-circular closure mechanism.
+
+The windowed Omega theorem is necessary for the reverse direction of the variance characterization. It is not sufficient by itself to prove GRH.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove the windowed Omega theorem.
+
+This document does not prove the unconditional critical-scale variance bound.
+
+This document does not close `HW-PRIME-WEIL-004` or `HW-PRIME-WEIL-005`.
+
+This document does not construct a Hilbert-Polya operator.
+
+This document does not promote the prime/operator lane to theorem-grade RH progress.

--- a/tests/test_hw_open_009_windowed_omega.py
+++ b/tests/test_hw_open_009_windowed_omega.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGET = ROOT / "docs" / "prime-operator-lane" / "windowed-omega-theorem-target.md"
+REGISTER_NOTE = ROOT / "docs" / "prime-operator-lane" / "HW-OPEN-009-windowed-omega-register-note.md"
+
+
+class TestHWOpen009WindowedOmega(unittest.TestCase):
+    def test_target_document_exists_and_is_not_a_proof(self) -> None:
+        self.assertTrue(TARGET.exists())
+        text = TARGET.read_text(encoding="utf-8")
+        self.assertIn("HW-OPEN-009", text)
+        self.assertIn("proof-target document", text)
+        self.assertIn("does not prove RH", text)
+        self.assertIn("does not prove GRH", text)
+        self.assertIn("does not prove the windowed Omega theorem", text)
+
+    def test_windowed_omega_statement_is_present(self) -> None:
+        text = TARGET.read_text(encoding="utf-8")
+        for token in [
+            "rho_0 = sigma_0 + i t_0",
+            "sigma_0 > 1/2",
+            "|psi_{W_K}(chi)| >= c 10^(K sigma_0)",
+            "infinitely many `K`",
+            "positive-density subsequence",
+        ]:
+            self.assertIn(token, text)
+
+    def test_paths_and_obligations_are_pinned(self) -> None:
+        text = TARGET.read_text(encoding="utf-8")
+        for token in [
+            "Path A — Direct phase route",
+            "Path B — Cesaro / second-moment route",
+            "same-real-part",
+            "off-diagonal cross terms",
+            "explicit-formula error",
+            "Convert positive normalized second moment",
+        ]:
+            self.assertIn(token, text)
+
+    def test_variance_route_boundary_is_pinned(self) -> None:
+        text = TARGET.read_text(encoding="utf-8")
+        for token in [
+            "HW-PRIME-WEIL-005",
+            "unconditional critical-scale variance upper bound",
+            "does not by itself supply the missing unconditional upper bound",
+            "Var_P(W_K)",
+        ]:
+            self.assertIn(token, text)
+
+    def test_register_note_exists_and_preserves_non_claims(self) -> None:
+        self.assertTrue(REGISTER_NOTE.exists())
+        text = REGISTER_NOTE.read_text(encoding="utf-8")
+        for token in [
+            "HW-OPEN-009",
+            "windowed Omega theorem",
+            "Canonical target document",
+            "promising partial route",
+            "does not prove the unconditional variance bound",
+        ]:
+            self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the HW-OPEN-009 windowed Omega target surface for Richter-window character sums.

Files:

- `docs/prime-operator-lane/windowed-omega-theorem-target.md`
- `docs/prime-operator-lane/HW-OPEN-009-windowed-omega-register-note.md`
- `tests/test_hw_open_009_windowed_omega.py`

Scope: proof-target / open-problem surface only. It records Path A, Path B, and remaining obligations. No theorem promotion.

STOP gate: opened for review only.