### PR TITLE
prime-weil: add HW-PRIME-WEIL-006 equidistribution decomposition

### DIFF
--- a/docs/prime-operator-lane/HW-PRIME-WEIL-006-equidistribution-decomposition.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-006-equidistribution-decomposition.md
@@ -1,0 +1,192 @@
+# HW-PRIME-WEIL-006 — Equidistribution Decomposition Surface
+
+Status: proved finite decomposition and bound; finite diagnostic barrier map.  
+Claim class: theorem-grade for the finite decomposition identities; method-grade for barrier interpretation.  
+Lane: prime/operator lane, fixed-modulus Richter-window variance route.  
+Depends on: `HW-PRIME-WEIL-005`, `HW-OPEN-009`, finite Parseval variance identity.
+
+## Purpose
+
+This document records the sharp finite equidistribution decomposition that sits underneath the Richter-window variance barrier.
+
+It isolates the exact arithmetic fact:
+
+```text
+character sums are Fourier transforms of residue-class equidistribution errors.
+```
+
+This is unconditional and finite. It does not prove RH or GRH.
+
+## Section 1 — Exact decomposition
+
+Let `P` be fixed and let `G_P=(Z/PZ)^x`. Let `chi` be a nontrivial character of `G_P`.
+
+For a Richter window `W_K`, define the residue-class Chebyshev mass:
+
+```text
+M_K(r) = sum_{p in W_K, p == r mod P} log p
+```
+
+and the average mass over the finite character quotient:
+
+```text
+bar(M)_K = (1 / |G_P / ker chi|) sum_{r in G_P / ker chi} M_K(r).
+```
+
+Define the residue-class equidistribution error:
+
+```text
+epsilon_K(r) = M_K(r) - bar(M)_K.
+```
+
+Then, for every nontrivial `chi`, since:
+
+```text
+sum_{r in G_P / ker chi} chi(r) = 0,
+```
+
+the main term drops out exactly and:
+
+```text
+psi_{W_K}(chi) = sum_{r in G_P / ker chi} chi(r) epsilon_K(r).
+```
+
+This is an exact finite identity.
+
+## Section 2 — Triangle bound
+
+The decomposition immediately gives:
+
+```text
+|psi_{W_K}(chi)|
+  <= sum_r |chi(r)| |epsilon_K(r)|
+  <= |G_P / ker chi| max_r |epsilon_K(r)|.
+```
+
+In particular, for a primitive mod-7 packet:
+
+```text
+|psi_{W_K}(chi_7)| <= 6 max_r |epsilon_K(r)|.
+```
+
+This is unconditional and finite.
+
+The bound shows that a square-root bound for the residue-class errors implies a square-root bound for the character sums.
+
+The converse requires the full nontrivial character packet and Fourier inversion, not a single character alone.
+
+## Section 3 — GRH equivalence at the residue-error level
+
+For the mod-7 character packet, the following is the correct theorem-candidate equivalence:
+
+```text
+GRH for all nontrivial L(s, chi) in the mod-7 packet
+  <=>
+max_r |epsilon_K(r)| = O(sqrt(10^K) log^2(10^K))
+```
+
+for the Richter-window family, with the usual explicit-formula and windowed-Omega obligations from `HW-PRIME-WEIL-005` and `HW-OPEN-009`.
+
+The forward direction follows from applying the GRH character-sum bound to all nontrivial mod-7 characters and using finite Fourier inversion on `(Z/7Z)^x`.
+
+The reverse direction follows because the finite Fourier transform of the residue-error vector gives all nontrivial character sums.
+
+This is a reformulation of the same GRH-strength square-root barrier, not a proof of GRH.
+
+## Section 4 — Empirical data for K=2..6
+
+For the primitive mod-7 component, the diagnostic records the finite ratios:
+
+```text
+max_r |epsilon_K(r)| / sqrt(10^K)
+```
+
+| K | `max_r |epsilon_K(r)|` | ratio to `sqrt(10^K)` | Comment |
+|---:|---:|---:|---|
+| 2 | about `2.49` | about `0.25` | below GRH-shaped envelope |
+| 3 | about `8.16` | about `0.26` | below GRH-shaped envelope |
+| 4 | about `45.67` | about `0.46` | below GRH-shaped envelope |
+| 5 | about `146.58` | about `0.46` | below GRH-shaped envelope |
+| 6 | about `220.00` | about `0.22` | below GRH-shaped envelope |
+
+These are finite diagnostics only. They are consistent with square-root-scale behavior and do not prove an asymptotic bound.
+
+## Section 5 — Digit-cycle oracle bound at resonant depth
+
+For `p=7`, base `10` has period:
+
+```text
+ord_7(10) = 6.
+```
+
+For the primitive mod-7 character used by the diagnostic:
+
+```text
+sum_{j=1}^6 chi_7(10^j mod 7) = 0.
+```
+
+The finite digit-cycle partial sums satisfy:
+
+```text
+max_m |sum_{j=1}^m chi_7(10^j mod 7)| <= 2.
+```
+
+At resonant depth `K=6`, the tool verifies the finite oracle-style bound:
+
+```text
+|psi_{W_6}(chi_7)| <= 2 log(10^6) sqrt(N_6 / 6),
+```
+
+where `N_6` is the prime count in `W_6`.
+
+This is a finite checked bound at the resonant depth. It is not claimed as an all-depth theorem. Extending it requires a distribution hypothesis or a proof controlling how primes populate the digit-cycle compartments across all Richter windows.
+
+## Section 6 — Variance concentration
+
+The full `G_210` character family decomposes through CRT coordinates. Let `Delta_{p=7}(K)` denote the finite energy packet from all `G_210` characters with nontrivial mod-7 coordinate.
+
+The diagnostic computes:
+
+```text
+Delta_{p=7}(K) / Var_total(K)
+```
+
+for finite depths. At depths `K=2` and `K=3`, the mod-7 packet accounts for more than `85%` of the nontrivial character energy. In the observed windows, the obstruction concentrates strongly in the mod-7 packet.
+
+This is finite numerical evidence. It does not prove asymptotic concentration.
+
+## Section 7 — Barrier location
+
+The finite decomposition proves that the character-sum barrier is exactly a residue-class equidistribution barrier:
+
+```text
+psi_{W_K}(chi) = Fourier(epsilon_K)(chi).
+```
+
+For mod 7, proving:
+
+```text
+max_r |epsilon_K(r)| = O(sqrt(10^K) poly(K))
+```
+
+is GRH-strength for the associated character packet.
+
+Thus the barrier has been localized at the finest finite resolution currently available: residue-class equidistribution error inside Richter windows.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove the unconditional square-root bound on `max_r |epsilon_K(r)|` for all `K`.
+
+This document does not prove the windowed Omega theorem.
+
+This document does not claim the digit-cycle oracle bound extends to all depths.
+
+This document does not close the square-root barrier identified in `HW-PRIME-WEIL-005`.
+
+This document does not construct a Hilbert-Polya operator.
+
+This document does not promote the prime/operator lane to theorem-grade RH progress.

--- a/docs/prime-operator-lane/windowed-omega-theorem-target.md
+++ b/docs/prime-operator-lane/windowed-omega-theorem-target.md
@@ -102,11 +102,25 @@ A target normalized second moment is:
 (1/N) sum_{K=1}^N |psi_{W_K}(chi)|^2 / 10^(2K sigma_0).
 ```
 
-The diagonal contribution from `rho_0` is positive and has a geometric-series normalization. In the single-zero model, it gives a positive limiting lower contribution of the form:
+The diagonal contribution from the selected zero `rho_0` is positive. In the single-zero window model:
 
 ```text
-C_0^2 * positive_geometric_factor.
+|A_K(rho_0)|^2 / 10^(2K sigma_0) = C_0^2.
 ```
+
+Thus the diagonal part has positive Cesaro contribution:
+
+```text
+(1/N) sum_{K=1}^N |A_K(rho_0)|^2 / 10^(2K sigma_0) = C_0^2 > 0.
+```
+
+If one instead studies cumulative partial sums normalized at the terminal scale `N`, the same positivity appears through a geometric factor such as:
+
+```text
+C_0^2 * r / (r - 1),    r = 10^(2 sigma_0).
+```
+
+Both formulations record the same point: the diagonal contribution is strictly positive after the correct normalization.
 
 Therefore, in the single-dominant-zero model, the normalized second moment has positive lower density and implies:
 
@@ -115,6 +129,8 @@ Therefore, in the single-dominant-zero model, the normalized second moment has p
 ```
 
 for a positive-density subsequence of windows.
+
+This is a partial discharge of Path B at the diagonal-spine level only.
 
 ## What Path B still owes
 

--- a/tests/test_equidistribution_decomposition.py
+++ b/tests/test_equidistribution_decomposition.py
@@ -1,0 +1,73 @@
+import math
+import unittest
+
+from tools.check_equidistribution_decomposition import (
+    chi7,
+    compute_variance_by_prime,
+    digit_cycle_sum,
+    epsilon,
+    grh_envelope,
+    max_digit_cycle_partial_sum,
+    max_epsilon,
+    oracle_bound_at_resonant_depth,
+    prime_count_window,
+    psi_chi7,
+    psi_chi7_via_epsilon,
+)
+
+
+class TestEquidistributionDecomposition(unittest.TestCase):
+    def test_decomposition_is_exact(self) -> None:
+        for depth in (2, 3):
+            direct = psi_chi7(depth)
+            via_eps = psi_chi7_via_epsilon(depth)
+            self.assertLess(abs(direct - via_eps), 1e-8)
+
+    def test_triangle_bound_holds(self) -> None:
+        for depth in (2, 3, 4, 5, 6):
+            psi = abs(psi_chi7(depth))
+            bound = 6.0 * max_epsilon(depth)
+            self.assertLessEqual(psi, bound + 1e-8)
+
+    def test_digit_cycle_sum_is_exactly_zero(self) -> None:
+        self.assertLess(abs(digit_cycle_sum()), 1e-12)
+
+    def test_digit_cycle_max_partial_sum(self) -> None:
+        self.assertLessEqual(max_digit_cycle_partial_sum(), 2.001)
+
+    def test_oracle_bound_at_resonant_depth(self) -> None:
+        actual = abs(psi_chi7(6))
+        n6 = prime_count_window(6)
+        oracle = 2.0 * math.log(10**6) * math.sqrt(n6 / 6.0)
+        self.assertAlmostEqual(oracle, oracle_bound_at_resonant_depth(6), places=10)
+        self.assertLessEqual(actual, oracle)
+
+    def test_empirical_ratio_within_grh_envelope(self) -> None:
+        for depth in (2, 3, 4, 5, 6):
+            ratio = abs(psi_chi7(depth)) / math.sqrt(10**depth)
+            self.assertLess(ratio, grh_envelope(depth))
+
+    def test_p7_packet_dominates_variance(self) -> None:
+        for depth in (2, 3):
+            delta7, var_total = compute_variance_by_prime(depth)
+            self.assertGreater(delta7 / var_total, 0.85)
+
+    def test_equidistribution_error_controls_character_sum(self) -> None:
+        for depth in (2, 3, 4, 5, 6):
+            psi = abs(psi_chi7(depth))
+            max_eps = max(abs(epsilon(residue, depth)) for residue in range(1, 7))
+            if max_eps > 0.01:
+                self.assertLessEqual(psi / max_eps, 6.0 + 1e-10)
+
+    def test_barrier_remains_open(self) -> None:
+        unconditional_sqrt_bound_proved = False
+        self.assertFalse(unconditional_sqrt_bound_proved)
+
+    def test_chi7_is_nontrivial(self) -> None:
+        values = {round(abs(chi7(1, residue)), 12) for residue in range(1, 7)}
+        self.assertEqual(values, {1.0})
+        self.assertLess(abs(sum(chi7(1, residue) for residue in range(1, 7))), 1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hw_open_009_windowed_omega.py
+++ b/tests/test_hw_open_009_windowed_omega.py
@@ -1,3 +1,4 @@
+import cmath
 from pathlib import Path
 import unittest
 
@@ -39,6 +40,29 @@ class TestHWOpen009WindowedOmega(unittest.TestCase):
             "Convert positive normalized second moment",
         ]:
             self.assertIn(token, text)
+
+    def test_path_b_diagonal_cesaro_is_positive(self) -> None:
+        delta = 0.1
+        gamma = 14.1347
+        rho_0 = complex(0.5 + delta, gamma)
+        sigma_0 = rho_0.real
+        c0 = abs((1 - 10 ** (-rho_0)) / rho_0)
+        window_cesaro = c0**2
+        terminal_scale_r = 10 ** (2 * sigma_0)
+        terminal_scale_cesaro = c0**2 * terminal_scale_r / (terminal_scale_r - 1)
+        self.assertGreater(window_cesaro, 0.0)
+        self.assertGreater(terminal_scale_cesaro, 0.0)
+
+    def test_path_b_partial_discharge_recorded(self) -> None:
+        text = TARGET.read_text(encoding="utf-8")
+        for token in [
+            "This is a partial discharge of Path B at the diagonal-spine level only",
+            "The diagonal contribution from the selected zero `rho_0` is positive",
+            "C_0^2 > 0",
+        ]:
+            self.assertIn(token, text)
+        path_b_fully_discharged = False
+        self.assertFalse(path_b_fully_discharged)
 
     def test_variance_route_boundary_is_pinned(self) -> None:
         text = TARGET.read_text(encoding="utf-8")

--- a/tools/check_equidistribution_decomposition.py
+++ b/tools/check_equidistribution_decomposition.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Equidistribution decomposition diagnostic for the Richter-window lane.
+
+This tool verifies the exact decomposition
+
+    psi_{W_K}(chi_7) = sum_r chi_7(r) * epsilon_K(r)
+
+for the primitive mod-7 component and reports the finite barrier diagnostics used
+by HW-PRIME-WEIL-006.
+
+It is a finite arithmetic diagnostic. It does not prove RH, GRH, a windowed
+Omega theorem, or an unconditional variance bound.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Dict, Iterable, List, Tuple
+
+from tools.check_finite_character_operator import (
+    MODULUS,
+    CharacterIndex,
+    build_dlog_table,
+    character_indices,
+    character_value,
+)
+
+MOD7_GENERATOR = 3
+CHI7_EXPONENT = 1
+
+
+@dataclass(frozen=True)
+class EquidistributionRow:
+    depth: int
+    prime_count: int
+    max_epsilon: float
+    psi_chi7_abs: float
+    psi_over_sqrt: float
+    grh_envelope: float
+    grh_ratio: float
+    oracle_bound: float | None
+    oracle_ratio: float | None
+
+
+@lru_cache(maxsize=None)
+def primes_up_to_sieve(limit: int) -> Tuple[int, ...]:
+    if limit < 2:
+        return tuple()
+    sieve = bytearray(b"\x01") * (limit + 1)
+    sieve[0:2] = b"\x00\x00"
+    root = int(limit**0.5)
+    for p in range(2, root + 1):
+        if sieve[p]:
+            start = p * p
+            sieve[start : limit + 1 : p] = b"\x00" * (((limit - start) // p) + 1)
+    return tuple(i for i in range(limit + 1) if sieve[i])
+
+
+@lru_cache(maxsize=None)
+def primes_in_window(depth: int) -> Tuple[int, ...]:
+    if depth < 1:
+        raise ValueError("depth must be positive")
+    low = 10 ** (depth - 1)
+    high = 10**depth
+    return tuple(p for p in primes_up_to_sieve(high - 1) if low <= p < high)
+
+
+@lru_cache(maxsize=None)
+def mod7_dlog() -> Dict[int, int]:
+    table: Dict[int, int] = {}
+    value = 1
+    for exponent in range(6):
+        table[value] = exponent
+        value = (value * MOD7_GENERATOR) % 7
+    if set(table) != {1, 2, 3, 4, 5, 6}:
+        raise RuntimeError("3 should generate (Z/7Z)^x")
+    return table
+
+
+def chi7(exponent: int, residue: int) -> complex:
+    """Primitive mod-7 character with chi(3)=exp(2*pi*i*exponent/6)."""
+
+    r = residue % 7
+    if math.gcd(r, 7) != 1:
+        return 0j
+    return cmath.exp(2j * math.pi * exponent * mod7_dlog()[r] / 6)
+
+
+def residue_masses_mod7(depth: int) -> Dict[int, float]:
+    masses = {r: 0.0 for r in range(1, 7)}
+    for prime in primes_in_window(depth):
+        residue = prime % 7
+        if residue:
+            masses[residue] += math.log(prime)
+    return masses
+
+
+def epsilon(residue: int, depth: int) -> float:
+    masses = residue_masses_mod7(depth)
+    mean = sum(masses.values()) / 6.0
+    return masses[residue] - mean
+
+
+def psi_chi7(depth: int, exponent: int = CHI7_EXPONENT) -> complex:
+    return sum(math.log(prime) * chi7(exponent, prime) for prime in primes_in_window(depth) if prime % 7)
+
+
+def psi_chi7_via_epsilon(depth: int, exponent: int = CHI7_EXPONENT) -> complex:
+    return sum(chi7(exponent, residue) * epsilon(residue, depth) for residue in range(1, 7))
+
+
+def max_epsilon(depth: int) -> float:
+    return max(abs(epsilon(residue, depth)) for residue in range(1, 7))
+
+
+def grh_envelope(depth: int) -> float:
+    return math.log(10**depth) ** 2
+
+
+def oracle_bound_at_resonant_depth(depth: int = 6) -> float:
+    prime_count = len(primes_in_window(depth))
+    return 2.0 * math.log(10**depth) * math.sqrt(prime_count / 6.0)
+
+
+def digit_cycle_sum(exponent: int = CHI7_EXPONENT) -> complex:
+    return sum(chi7(exponent, pow(10, j, 7)) for j in range(1, 7))
+
+
+def digit_cycle_partial_sums(exponent: int = CHI7_EXPONENT) -> Tuple[complex, ...]:
+    total = 0j
+    partials: List[complex] = []
+    for j in range(1, 7):
+        total += chi7(exponent, pow(10, j, 7))
+        partials.append(total)
+    return tuple(partials)
+
+
+def max_digit_cycle_partial_sum(exponent: int = CHI7_EXPONENT) -> float:
+    return max(abs(value) for value in digit_cycle_partial_sums(exponent))
+
+
+def psi_for_g210_character(depth: int, index: CharacterIndex) -> complex:
+    dlog_table = build_dlog_table()
+    total = 0j
+    for prime in primes_in_window(depth):
+        residue = prime % MODULUS
+        if math.gcd(residue, MODULUS) == 1:
+            total += math.log(prime) * character_value(index, residue, dlog_table)
+    return total
+
+
+def compute_variance_by_prime(depth: int) -> Tuple[float, float]:
+    """Return the p=7 packet energy and total nontrivial character energy.
+
+    The p=7 packet is the sum over all G_210 characters with nontrivial mod-7
+    coordinate. This is the quantity that empirically dominates the finite
+    variance in the current diagnostic windows.
+    """
+
+    total = 0.0
+    p7_packet = 0.0
+    for index in character_indices():
+        if index == (0, 0, 0):
+            continue
+        energy = abs(psi_for_g210_character(depth, index)) ** 2
+        total += energy
+        if index[2] != 0:
+            p7_packet += energy
+    return p7_packet, total
+
+
+def equidistribution_row(depth: int) -> EquidistributionRow:
+    psi_abs = abs(psi_chi7(depth))
+    sqrt_scale = math.sqrt(10**depth)
+    psi_over_sqrt = psi_abs / sqrt_scale
+    envelope = grh_envelope(depth)
+    oracle = oracle_bound_at_resonant_depth(depth) if depth == 6 else None
+    return EquidistributionRow(
+        depth=depth,
+        prime_count=len(primes_in_window(depth)),
+        max_epsilon=max_epsilon(depth),
+        psi_chi7_abs=psi_abs,
+        psi_over_sqrt=psi_over_sqrt,
+        grh_envelope=envelope,
+        grh_ratio=psi_over_sqrt / envelope,
+        oracle_bound=oracle,
+        oracle_ratio=psi_abs / oracle if oracle else None,
+    )
+
+
+def diagnostic_rows(depths: Iterable[int] = (2, 3, 4, 5, 6)) -> Tuple[EquidistributionRow, ...]:
+    return tuple(equidistribution_row(depth) for depth in depths)
+
+
+def run_checks() -> Tuple[EquidistributionRow, ...]:
+    rows = diagnostic_rows()
+    for depth in (2, 3, 4, 5, 6):
+        direct = psi_chi7(depth)
+        via_eps = psi_chi7_via_epsilon(depth)
+        if abs(direct - via_eps) > 1e-8:
+            raise AssertionError((depth, direct, via_eps))
+        if abs(direct) > 6.0 * max_epsilon(depth) + 1e-8:
+            raise AssertionError(f"triangle bound failed at depth {depth}")
+        if abs(direct) / math.sqrt(10**depth) >= grh_envelope(depth):
+            raise AssertionError(f"finite diagnostic exceeded GRH-shaped envelope at depth {depth}")
+    if abs(digit_cycle_sum()) > 1e-12:
+        raise AssertionError("digit-cycle sum should vanish")
+    if max_digit_cycle_partial_sum() > 2.001:
+        raise AssertionError("digit-cycle partial-sum bound failed")
+    if abs(psi_chi7(6)) > oracle_bound_at_resonant_depth(6):
+        raise AssertionError("resonant-depth oracle bound failed")
+    for depth in (2, 3):
+        p7_packet, total = compute_variance_by_prime(depth)
+        if total <= 0 or p7_packet / total <= 0.85:
+            raise AssertionError(f"p=7 packet did not dominate at depth {depth}")
+    return rows
+
+
+def main() -> None:
+    print("Equidistribution decomposition diagnostic for chi_7")
+    for row in run_checks():
+        oracle = "N/A" if row.oracle_bound is None else f"{row.oracle_bound:.12f}"
+        oracle_ratio = "N/A" if row.oracle_ratio is None else f"{row.oracle_ratio:.12f}"
+        p7_packet, total = compute_variance_by_prime(row.depth)
+        print(
+            f"K={row.depth} primes={row.prime_count} psi={row.psi_chi7_abs:.12f} "
+            f"max_eps={row.max_epsilon:.12f} psi/sqrt={row.psi_over_sqrt:.12f} "
+            f"grh_env={row.grh_envelope:.12f} ratio={row.grh_ratio:.12f} "
+            f"p7_share={p7_packet / total:.12f} oracle={oracle} oracle_ratio={oracle_ratio}"
+        )
+    print(f"digit-cycle sum: {digit_cycle_sum():.12g}")
+    print(f"max digit-cycle partial sum: {max_digit_cycle_partial_sum():.12f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_equidistribution_decomposition.py
+++ b/tools/check_equidistribution_decomposition.py
@@ -68,6 +68,10 @@ def primes_in_window(depth: int) -> Tuple[int, ...]:
     return tuple(p for p in primes_up_to_sieve(high - 1) if low <= p < high)
 
 
+def prime_count_window(depth: int) -> int:
+    return len(primes_in_window(depth))
+
+
 @lru_cache(maxsize=None)
 def mod7_dlog() -> Dict[int, int]:
     table: Dict[int, int] = {}
@@ -121,7 +125,7 @@ def grh_envelope(depth: int) -> float:
 
 
 def oracle_bound_at_resonant_depth(depth: int = 6) -> float:
-    prime_count = len(primes_in_window(depth))
+    prime_count = prime_count_window(depth)
     return 2.0 * math.log(10**depth) * math.sqrt(prime_count / 6.0)
 
 
@@ -180,7 +184,7 @@ def equidistribution_row(depth: int) -> EquidistributionRow:
     oracle = oracle_bound_at_resonant_depth(depth) if depth == 6 else None
     return EquidistributionRow(
         depth=depth,
-        prime_count=len(primes_in_window(depth)),
+        prime_count=prime_count_window(depth),
         max_epsilon=max_epsilon(depth),
         psi_chi7_abs=psi_abs,
         psi_over_sqrt=psi_over_sqrt,


### PR DESCRIPTION
## Summary

Adds HW-PRIME-WEIL-006, the equidistribution decomposition surface for the Richter-window variance route, plus a finite diagnostic tool and tests.

Files:

- `docs/prime-operator-lane/HW-PRIME-WEIL-006-equidistribution-decomposition.md`
- `tools/check_equidistribution_decomposition.py`
- `tests/test_equidistribution_decomposition.py`
- updates `docs/prime-operator-lane/windowed-omega-theorem-target.md`
- updates `tests/test_hw_open_009_windowed_omega.py`

## Claim posture

Finite decomposition and triangle bound are exact finite identities. The GRH/residue-error equivalence is a theorem-candidate/barrier formulation. The digit-cycle oracle bound is finite/resonant-depth scoped. No RH/GRH proof and no unconditional variance bound.

## STOP gate

Opened for review only. Do not merge until reviewed.