### PR TITLE
prime-weil: add p=11 non-cancelling variance-share diagnostic

### DIFF
--- a/docs/prime-operator-lane/HW-PRIME-WEIL-010-p11-variance-share.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-010-p11-variance-share.md
@@ -1,0 +1,141 @@
+# HW-PRIME-WEIL-010 — p=11 Non-Cancelling Variance Share
+
+Status: finite diagnostic surface.  
+Claim class: finite computation / variance-share comparison, not theorem-grade analytic progress.  
+Lane: prime/operator lane, Richter-window / partial-orbit packet surface.  
+Depends on: `HW-PRIME-WEIL-009`.
+
+## Purpose
+
+This document measures the finite energy share carried by the non-cancelling `p=11` character sublayer after the `P=2310` extension.
+
+The local `p=11` orbit is:
+
+```text
+<10> = {1,10} = {1,-1} subset (Z/11Z)^x.
+```
+
+The local nontrivial character split is:
+
+```text
+5 cancelling characters      chi(10) = -1
+4 non-cancelling characters  chi(10) = +1
+```
+
+The finite local count baseline for the non-cancelling part of the new `p=11` layer is therefore:
+
+```text
+4 / 9 = 0.444444444444...
+```
+
+This document compares the measured non-cancelling energy share against that count baseline.
+
+## Exact local split
+
+Let local characters modulo `11` be indexed by exponent `e in {1,...,9}`.
+
+Because `10 = -1 mod 11`, the orbit sum is:
+
+```text
+1 + chi(10).
+```
+
+Therefore:
+
+```text
+chi(10) = -1  =>  1 + chi(10) = 0
+chi(10) = +1  =>  1 + chi(10) = 2
+```
+
+Odd exponent characters cancel. Even exponent characters do not cancel.
+
+The non-cancelling value is exactly `2`, the orbit size.
+
+## CRT layer split
+
+For:
+
+```text
+P = 2310 = 2 * 3 * 5 * 7 * 11,
+```
+
+the full character group has size:
+
+```text
+phi(2310) = 480.
+```
+
+The old `P=210` layer contains:
+
+```text
+48 characters.
+```
+
+The new `p=11` layer contains:
+
+```text
+432 characters.
+```
+
+The new layer splits as:
+
+```text
+240 cancelling characters      = 48 * 5
+192 non-cancelling characters  = 48 * 4
+```
+
+The full-nontrivial-count baselines are:
+
+```text
+new p=11 layer / all nontrivial characters = 432 / 479 ~= 0.901879
+p=11 non-cancelling layer / all nontrivial characters = 192 / 479 ~= 0.400835
+p=11 non-cancelling layer / new p=11 layer = 4 / 9 ~= 0.444444
+```
+
+## Finite measured values
+
+The diagnostic computes Chebyshev-weighted character energies over Richter windows at depths `K=2,3,4`.
+
+| K | `p11_new / total` | `p11_non / p11_new` | `p11_non / total` |
+|---:|---:|---:|---:|
+| 2 | `0.938218008866` | `0.444444444444` | `0.416985781718` |
+| 3 | `0.961859768615` | `0.462182505791` | `0.444554758078` |
+| 4 | `0.967468868352` | `0.483889986895` | `0.468148498029` |
+
+The finite data show that the new `p=11` layer carries most of the `P=2310` nontrivial energy at these depths. Within that new layer, the non-cancelling share begins at the local `4/9` count baseline and rises modestly at `K=3,4`.
+
+## Interpretation
+
+The finite result supports the orbit-classification diagnosis:
+
+```text
+p=11 is between inert/degenerate and full-orbit behavior.
+```
+
+It has exact local cancellation for the odd-exponent characters and exact constructive orbit sum `2` for the even-exponent characters.
+
+The non-cancelling sublayer carries the packet obstruction associated with the partial orbit.
+
+## Boundary
+
+The local `4/9` baseline is a character-count baseline, not an asymptotic variance law.
+
+The finite measurements are diagnostic only. They do not prove that the variance decomposition respects the local orbit count asymptotically.
+
+A future theorem would need to control how prime-window mass distributes across the `p=11` CRT fibers and across the inherited `P=210` coordinates.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove Artin's conjecture.
+
+This document does not prove an unconditional variance bound.
+
+This document does not prove an asymptotic `p=11` packet share.
+
+This document does not close the square-root barrier.
+
+This document does not claim that local orbit-count baselines determine prime-window energy shares asymptotically.

--- a/tests/test_p11_variance_share.py
+++ b/tests/test_p11_variance_share.py
@@ -1,0 +1,56 @@
+import math
+import unittest
+
+from tools.check_p11_variance_share import (
+    FULL_NONTRIVIAL_COUNT_BASELINE,
+    LOCAL_NONCANCELLING_BASELINE,
+    NEW_LAYER_COUNT_BASELINE,
+    run_checks,
+    variance_share_row,
+)
+
+
+class TestP11VarianceShare(unittest.TestCase):
+    def test_baselines_are_exact_counts(self) -> None:
+        self.assertAlmostEqual(LOCAL_NONCANCELLING_BASELINE, 4.0 / 9.0, places=15)
+        self.assertAlmostEqual(FULL_NONTRIVIAL_COUNT_BASELINE, 192.0 / 479.0, places=15)
+        self.assertAlmostEqual(NEW_LAYER_COUNT_BASELINE, 432.0 / 479.0, places=15)
+
+    def test_run_checks(self) -> None:
+        rows = run_checks()
+        self.assertEqual([row.depth for row in rows], [2, 3, 4])
+
+    def test_depth_2_values_match_computation(self) -> None:
+        row = variance_share_row(2)
+        self.assertAlmostEqual(row.p11_new_share_total, 0.9382180088664248, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_share_new, 0.4444444444444449, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_share_total, 0.4169857817184115, places=12)
+
+    def test_depth_3_values_match_computation(self) -> None:
+        row = variance_share_row(3)
+        self.assertAlmostEqual(row.p11_new_share_total, 0.9618597686152422, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_share_new, 0.46218250579118775, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_share_total, 0.4445547580783247, places=12)
+
+    def test_depth_4_values_match_computation(self) -> None:
+        row = variance_share_row(4)
+        self.assertAlmostEqual(row.p11_new_share_total, 0.967468868352348, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_share_new, 0.4838899868953186, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_share_total, 0.4681484980286464, places=12)
+
+    def test_non_cancelling_share_is_near_local_baseline(self) -> None:
+        for depth in (2, 3, 4):
+            row = variance_share_row(depth)
+            self.assertLess(abs(row.p11_noncancelling_share_new - LOCAL_NONCANCELLING_BASELINE), 0.05)
+
+    def test_document_claim_is_finite_diagnostic_only(self) -> None:
+        proves_grh = False
+        proves_unconditional_variance_bound = False
+        proves_asymptotic_packet_share = False
+        self.assertFalse(proves_grh)
+        self.assertFalse(proves_unconditional_variance_bound)
+        self.assertFalse(proves_asymptotic_packet_share)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_p11_variance_share.py
+++ b/tools/check_p11_variance_share.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""p=11 non-cancelling variance-share diagnostic.
+
+This tool compares the finite p=11 non-cancelling energy share against the
+local character-count baseline 4/9 in the P=2310 packet.
+
+It is a finite diagnostic. It does not prove an asymptotic law, RH, GRH,
+Artin's conjecture, or an unconditional variance bound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+from tools.check_p11_partial_orbit_packet import PacketEnergyRow, packet_energy_row
+
+LOCAL_NONCANCELLING_BASELINE = 4.0 / 9.0
+FULL_NONTRIVIAL_COUNT_BASELINE = 192.0 / 479.0
+NEW_LAYER_COUNT_BASELINE = 432.0 / 479.0
+
+
+@dataclass(frozen=True)
+class P11VarianceShareRow:
+    depth: int
+    total_nontrivial_energy: float
+    p11_new_energy: float
+    p11_noncancelling_energy: float
+    p11_new_share_total: float
+    p11_noncancelling_share_new: float
+    p11_noncancelling_share_total: float
+    deviation_from_local_baseline: float
+
+
+def variance_share_row(depth: int) -> P11VarianceShareRow:
+    row: PacketEnergyRow = packet_energy_row(depth)
+    p11_new_share_total = row.p11_new_energy / row.total_nontrivial_energy
+    p11_noncancelling_share_new = row.p11_noncancelling_energy / row.p11_new_energy
+    p11_noncancelling_share_total = row.p11_noncancelling_energy / row.total_nontrivial_energy
+    return P11VarianceShareRow(
+        depth=depth,
+        total_nontrivial_energy=row.total_nontrivial_energy,
+        p11_new_energy=row.p11_new_energy,
+        p11_noncancelling_energy=row.p11_noncancelling_energy,
+        p11_new_share_total=p11_new_share_total,
+        p11_noncancelling_share_new=p11_noncancelling_share_new,
+        p11_noncancelling_share_total=p11_noncancelling_share_total,
+        deviation_from_local_baseline=p11_noncancelling_share_new - LOCAL_NONCANCELLING_BASELINE,
+    )
+
+
+def variance_share_rows(depths: Iterable[int] = (2, 3, 4)) -> Tuple[P11VarianceShareRow, ...]:
+    return tuple(variance_share_row(depth) for depth in depths)
+
+
+def run_checks() -> Tuple[P11VarianceShareRow, ...]:
+    rows = variance_share_rows()
+    for row in rows:
+        if not 0.0 <= row.p11_new_share_total <= 1.0:
+            raise AssertionError(row)
+        if not 0.0 <= row.p11_noncancelling_share_new <= 1.0:
+            raise AssertionError(row)
+        if not 0.0 <= row.p11_noncancelling_share_total <= 1.0:
+            raise AssertionError(row)
+    # Finite observed values for depths 2..4 stay close to the local 4/9 count baseline.
+    if abs(rows[0].p11_noncancelling_share_new - LOCAL_NONCANCELLING_BASELINE) > 1e-10:
+        raise AssertionError(rows[0])
+    if abs(rows[1].p11_noncancelling_share_new - LOCAL_NONCANCELLING_BASELINE) > 0.03:
+        raise AssertionError(rows[1])
+    if abs(rows[2].p11_noncancelling_share_new - LOCAL_NONCANCELLING_BASELINE) > 0.05:
+        raise AssertionError(rows[2])
+    return rows
+
+
+def main() -> None:
+    print("p=11 variance-share diagnostic")
+    print(f"local non-cancelling baseline: {LOCAL_NONCANCELLING_BASELINE:.12f}")
+    print(f"full nontrivial count baseline: {FULL_NONTRIVIAL_COUNT_BASELINE:.12f}")
+    print(f"new layer count baseline: {NEW_LAYER_COUNT_BASELINE:.12f}")
+    for row in run_checks():
+        print(
+            f"K={row.depth} p11_new/total={row.p11_new_share_total:.12f} "
+            f"p11_non/new={row.p11_noncancelling_share_new:.12f} "
+            f"p11_non/total={row.p11_noncancelling_share_total:.12f} "
+            f"deviation={row.deviation_from_local_baseline:.12f}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds HW-PRIME-WEIL-010, a finite p=11 non-cancelling variance-share diagnostic.

Files:

- `docs/prime-operator-lane/HW-PRIME-WEIL-010-p11-variance-share.md`
- `tools/check_p11_variance_share.py`
- `tests/test_p11_variance_share.py`

## Claim posture

Finite diagnostic only. Compares the measured p=11 non-cancelling energy share against the local 4/9 character-count baseline. No RH/GRH proof, no Artin proof, no unconditional variance bound, and no asymptotic packet-share claim.

## STOP gate

Opened for review only. Do not merge until reviewed.