### PR TITLE
prime-weil: add HW-OPEN-011 character-count dilution problem

### DIFF
--- a/docs/prime-operator-lane/HW-OPEN-011-character-count-dilution.md
+++ b/docs/prime-operator-lane/HW-OPEN-011-character-count-dilution.md
@@ -1,0 +1,198 @@
+# HW-OPEN-011 — Character-Count Dilution in the Primorial Tower
+
+Status: open transition problem / finite counting theorem surface.  
+Claim class: exact finite character-count decomposition; finite diagnostic interpretation, not asymptotic theorem.  
+Lane: prime/operator lane, primorial character-packet / variance-decomposition surface.  
+Depends on: `HW-PRIME-WEIL-009`, `HW-PRIME-WEIL-010`.
+
+## Purpose
+
+This document records the character-count dilution effect exposed by the `p=11` partial-orbit packet diagnostic.
+
+When the primorial modulus is extended from:
+
+```text
+P
+```
+
+to:
+
+```text
+Pq
+```
+
+by adding a new prime factor `q`, the new character layer is large. Even if the old layer contains a structurally strong full-orbit signal, the new layer may dominate finite variance by sheer character count if per-character energies are comparable.
+
+This document separates the exact finite counting statement from the open analytic question of whether energy follows character count asymptotically.
+
+## Exact character-count decomposition
+
+Let `P` be coprime to a new prime `q`, and compare character groups:
+
+```text
+G_P^*  and  G_{Pq}^*.
+```
+
+At the dual-character level:
+
+```text
+hat(G_{Pq}) ~= hat(G_P) x hat((Z/qZ)^x).
+```
+
+The old layer consists of characters with trivial `q`-coordinate:
+
+```text
+|old layer| = phi(P).
+```
+
+The full character group has size:
+
+```text
+|hat(G_{Pq})| = phi(P)(q-1).
+```
+
+The new `q` layer consists of characters with nontrivial `q`-coordinate:
+
+```text
+|new q layer| = phi(P)(q-2).
+```
+
+Among nontrivial characters of `G_{Pq}`, the count shares are:
+
+```text
+old layer nontrivial share = (phi(P)-1) / (phi(P)(q-1)-1)
+new q layer share          = phi(P)(q-2) / (phi(P)(q-1)-1).
+```
+
+As `q` grows with fixed `P`, the new-layer count share approaches:
+
+```text
+(q-2)/(q-1)
+```
+
+and the old-layer share approaches:
+
+```text
+1/(q-1).
+```
+
+This is exact finite counting.
+
+## The p=11 instance
+
+For:
+
+```text
+P=210,  q=11,  Pq=2310,
+```
+
+we have:
+
+```text
+phi(210)=48,
+phi(2310)=480.
+```
+
+Therefore:
+
+```text
+old P=210 layer = 48 characters,
+new p=11 layer = 432 characters.
+```
+
+Among all nontrivial `P=2310` characters:
+
+```text
+new p=11 layer share = 432 / 479 ~= 0.901879.
+```
+
+The measured finite energy share from `HW-PRIME-WEIL-010` is:
+
+| K | `p11_new / total` |
+|---:|---:|
+| 2 | `0.938218008866` |
+| 3 | `0.961859768615` |
+| 4 | `0.967468868352` |
+
+Thus, in the finite computed windows, the new `p=11` layer carries most of the `P=2310` energy.
+
+## Within-layer p=11 split
+
+The local `p=11` orbit is:
+
+```text
+<10> = {1,10} = {1,-1}.
+```
+
+The local nontrivial characters split as:
+
+```text
+5 cancelling characters      chi(10) = -1,
+4 non-cancelling characters  chi(10) = +1.
+```
+
+The non-cancelling local count baseline is:
+
+```text
+4/9 ~= 0.444444.
+```
+
+The measured finite non-cancelling share inside the new `p=11` layer is:
+
+| K | `p11_non / p11_new` |
+|---:|---:|
+| 2 | `0.444444444444` |
+| 3 | `0.462182505791` |
+| 4 | `0.483889986895` |
+
+The departure from `4/9` is a finite prime-race / residue-bias diagnostic. It should not be promoted to an asymptotic Chebyshev-bias theorem without a separate theorem-grade reference surface.
+
+## Interpretation
+
+Two mechanisms are now separated.
+
+First, orbit quality controls local cancellation structure:
+
+```text
+terminating / degenerate < partial orbit < full orbit.
+```
+
+Second, primorial extension controls character-count dilution:
+
+```text
+new q layer size = phi(P)(q-2).
+```
+
+As the primorial tower grows, each newly added prime introduces a large new character layer. The newest layer can dominate finite variance even if an older layer has cleaner orbit structure, because the new layer contains many more characters.
+
+Therefore the `p=7` full-orbit signal dominates at `P=210`, but after extending to `P=2310`, the `p=11` layer can overwhelm the old `P=210` layer by count and measured energy.
+
+## Open problem
+
+Determine whether energy follows character-count dilution asymptotically in the primorial tower.
+
+Concrete questions:
+
+1. For extension `P -> Pq`, does the new `q` layer typically carry a share comparable to its character-count share?
+2. How does orbit type of `q` modify that expected share?
+3. Can full-orbit Artin-prime components remain visible after many later primorial extensions?
+4. Is there a renormalized packet statistic that preserves orbit-quality information after character-count dilution?
+5. Can the finite variance decomposition be normalized so that orbit structure, not raw character count, becomes the primary observable?
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove Artin's conjecture.
+
+This document does not prove an unconditional variance bound.
+
+This document does not prove an asymptotic character-count dilution theorem.
+
+This document does not prove an asymptotic Chebyshev-bias theorem.
+
+This document does not claim that the newest primorial layer always dominates variance.
+
+This document does not close the square-root barrier identified in `HW-PRIME-WEIL-005`.

--- a/tests/test_character_count_dilution.py
+++ b/tests/test_character_count_dilution.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "prime-operator-lane" / "HW-OPEN-011-character-count-dilution.md"
+
+
+class TestCharacterCountDilution(unittest.TestCase):
+    def test_document_exists_and_is_open_problem(self) -> None:
+        self.assertTrue(DOC.exists())
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("HW-OPEN-011", text)
+        self.assertIn("open transition problem", text)
+        self.assertIn("finite counting theorem surface", text)
+
+    def test_exact_layer_count_formulas_for_p11(self) -> None:
+        phi_p = 48
+        q = 11
+        old_layer = phi_p
+        full_group = phi_p * (q - 1)
+        new_layer = phi_p * (q - 2)
+        nontrivial_total = full_group - 1
+        self.assertEqual(old_layer, 48)
+        self.assertEqual(full_group, 480)
+        self.assertEqual(new_layer, 432)
+        self.assertAlmostEqual(new_layer / nontrivial_total, 432 / 479, places=15)
+        self.assertAlmostEqual(old_layer / full_group, 0.1, places=15)
+
+    def test_local_p11_count_baseline(self) -> None:
+        local_cancelling = 5
+        local_noncancelling = 4
+        self.assertAlmostEqual(local_noncancelling / (local_cancelling + local_noncancelling), 4 / 9, places=15)
+        self.assertEqual(48 * local_cancelling, 240)
+        self.assertEqual(48 * local_noncancelling, 192)
+
+    def test_finite_p11_values_are_recorded(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "0.938218008866",
+            "0.961859768615",
+            "0.967468868352",
+            "0.444444444444",
+            "0.462182505791",
+            "0.483889986895",
+        ]:
+            self.assertIn(token, text)
+
+    def test_dilution_interpretation_is_bounded(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "character-count dilution",
+            "energy follows character-count dilution asymptotically",
+            "orbit type of `q`",
+            "renormalized packet statistic",
+        ]:
+            self.assertIn(token, text)
+
+    def test_non_claims_are_present(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "does not prove RH",
+            "does not prove GRH",
+            "does not prove an asymptotic character-count dilution theorem",
+            "does not prove an asymptotic Chebyshev-bias theorem",
+            "does not claim that the newest primorial layer always dominates variance",
+        ]:
+            self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds HW-OPEN-011 for the primorial tower character-count dilution problem.

Files:

- `docs/prime-operator-lane/HW-OPEN-011-character-count-dilution.md`
- `tests/test_character_count_dilution.py`

Scope: finite counting surface and open transition problem. No theorem promotion.

STOP gate: opened for review only.