### PR TITLE
prime-weil: add HW-PRIME-WEIL-011 renormalized packet energy

### DIFF
--- a/docs/prime-operator-lane/HW-PRIME-WEIL-011-renormalized-packet-energy.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-011-renormalized-packet-energy.md
@@ -1,0 +1,122 @@
+# HW-PRIME-WEIL-011 — Count-Normalized Packet Energy
+
+Status: finite diagnostic surface.  
+Claim class: finite computation / count-normalized packet-energy comparison, not theorem-grade analytic progress.  
+Lane: prime/operator lane, primorial tower variance decomposition.  
+Depends on: `HW-PRIME-WEIL-009`, `HW-PRIME-WEIL-010`, `HW-OPEN-011`.
+
+## Purpose
+
+This document defines and computes the count-normalized packet-energy statistic that removes raw character-count growth from primorial variance packets.
+
+Raw packet energy can be dominated by the newest primorial layer because the layer contains many characters. To compare orbit quality rather than raw count, normalize by the number of characters in each packet.
+
+## Definition
+
+For an orbit class or packet `C` inside the character group, define:
+
+```text
+E_C(K) = (sum_{chi in C} |psi_{W_K}(chi)|^2) / |C|.
+```
+
+This is energy per character.
+
+Under a null model in which energy is equidistributed across characters, `E_C(K)` should be comparable across packets. Deviations from equality measure packet-specific concentration after removing raw character-count dilution.
+
+## Packets compared
+
+At the `P=2310` level, compare:
+
+1. old `P=210` nontrivial layer: `47` characters;
+2. `p=11` cancelling sublayer: `240` characters;
+3. `p=11` non-cancelling sublayer: `192` characters.
+
+The p=11 cancelling sublayer consists of odd-exponent local characters with:
+
+```text
+chi(10) = -1.
+```
+
+The p=11 non-cancelling sublayer consists of even-exponent local characters with:
+
+```text
+chi(10) = +1.
+```
+
+## Finite measured values
+
+| K | old layer per character | p11 cancelling per character | p11 non-cancelling per character | non/cancel ratio | non/old ratio |
+|---:|---:|---:|---:|---:|---:|
+| 2 | `178.721087896189` | `295.278465033670` | `295.278465033670` | `1.000000000000` | `1.652174729404` |
+| 3 | `1476.995397722033` | `3923.097663316467` | `4214.224918349286` | `1.074208515825` | `2.853241739852` |
+| 4 | `10545.554180869645` | `31698.312041391290` | `37149.288448317450` | `1.171964248437` | `3.522744069317` |
+
+The finite data show:
+
+```text
+E_p11_non(K) = E_p11_cancel(K) at K=2,
+E_p11_non(K) > E_p11_cancel(K) for K=3,4.
+```
+
+The gap between non-cancelling and cancelling p=11 sublayers grows across the computed depths.
+
+## Interpretation
+
+The p=11 non-cancelling characters are blind to the reflection in the partial orbit `{1,-1}`:
+
+```text
+chi(10)=+1,
+1 + chi(10) = 2.
+```
+
+They see the length-2 orbit as constructively collapsed rather than cancelling.
+
+The p=11 cancelling characters see:
+
+```text
+chi(10)=-1,
+1 + chi(10) = 0.
+```
+
+Count-normalized energy therefore separates orbit-quality effects from raw packet size.
+
+The finite observed ordering is:
+
+```text
+p11 non-cancelling >= p11 cancelling > old P=210 layer
+```
+
+for the computed windows, with equality between the two p=11 sublayers at `K=2`.
+
+## Boundary
+
+This statistic is finite and diagnostic.
+
+It does not prove that the same ordering holds asymptotically.
+
+It does not prove that local orbit type alone determines energy per character.
+
+It does not prove that prime-window energy follows local character-count or local cancellation baselines at large depths.
+
+## Next questions
+
+1. Does `E_p11_non(K) / E_p11_cancel(K)` continue increasing at deeper feasible depths?
+2. Does the same count-normalized separation appear for later partial-orbit primes?
+3. Do full-orbit Artin packets have lower energy per character after count normalization?
+4. Is there a stable normalized statistic that preserves orbit quality across primorial extensions?
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove Artin's conjecture.
+
+This document does not prove an unconditional variance bound.
+
+This document does not prove an asymptotic packet-energy ordering.
+
+This document does not prove that non-cancelling partial-orbit characters always carry more energy per character.
+
+This document does not close the square-root barrier.

--- a/tests/test_renormalized_packet_energy.py
+++ b/tests/test_renormalized_packet_energy.py
@@ -1,0 +1,59 @@
+import unittest
+
+from tools.check_renormalized_packet_energy import (
+    OLD_LAYER_COUNT,
+    P11_CANCELLING_COUNT,
+    P11_NONCANCELLING_COUNT,
+    normalized_packet_energy_row,
+    run_checks,
+)
+
+
+class TestRenormalizedPacketEnergy(unittest.TestCase):
+    def test_packet_counts(self) -> None:
+        self.assertEqual(OLD_LAYER_COUNT, 47)
+        self.assertEqual(P11_CANCELLING_COUNT, 240)
+        self.assertEqual(P11_NONCANCELLING_COUNT, 192)
+
+    def test_run_checks(self) -> None:
+        rows = run_checks()
+        self.assertEqual([row.depth for row in rows], [2, 3, 4])
+
+    def test_depth_2_values(self) -> None:
+        row = normalized_packet_energy_row(2)
+        self.assertAlmostEqual(row.old_layer_energy_per_character, 178.72108789618892, places=12)
+        self.assertAlmostEqual(row.p11_cancelling_energy_per_character, 295.27846503367005, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_energy_per_character, 295.27846503367033, places=12)
+        self.assertAlmostEqual(row.noncancel_to_cancel_ratio, 1.0, places=12)
+
+    def test_depth_3_values(self) -> None:
+        row = normalized_packet_energy_row(3)
+        self.assertAlmostEqual(row.old_layer_energy_per_character, 1476.995397722033, places=12)
+        self.assertAlmostEqual(row.p11_cancelling_energy_per_character, 3923.0976633164673, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_energy_per_character, 4214.224918349286, places=12)
+        self.assertAlmostEqual(row.noncancel_to_cancel_ratio, 1.0742085158254022, places=12)
+
+    def test_depth_4_values(self) -> None:
+        row = normalized_packet_energy_row(4)
+        self.assertAlmostEqual(row.old_layer_energy_per_character, 10545.554180869645, places=12)
+        self.assertAlmostEqual(row.p11_cancelling_energy_per_character, 31698.31204139129, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_energy_per_character, 37149.28844831745, places=12)
+        self.assertAlmostEqual(row.noncancel_to_cancel_ratio, 1.1719642484372144, places=12)
+
+    def test_non_cancelling_ratio_increases_after_depth_2(self) -> None:
+        rows = run_checks()
+        self.assertAlmostEqual(rows[0].noncancel_to_cancel_ratio, 1.0, places=12)
+        self.assertGreater(rows[1].noncancel_to_cancel_ratio, rows[0].noncancel_to_cancel_ratio)
+        self.assertGreater(rows[2].noncancel_to_cancel_ratio, rows[1].noncancel_to_cancel_ratio)
+
+    def test_claim_is_finite_diagnostic_only(self) -> None:
+        proves_grh = False
+        proves_asymptotic_ordering = False
+        proves_unconditional_variance_bound = False
+        self.assertFalse(proves_grh)
+        self.assertFalse(proves_asymptotic_ordering)
+        self.assertFalse(proves_unconditional_variance_bound)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_renormalized_packet_energy.py
+++ b/tools/check_renormalized_packet_energy.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Count-normalized packet-energy diagnostic for the Prime-Weil lane.
+
+This tool removes raw character-count growth by computing energy per character
+for the old P=210 layer, the p=11 cancelling sublayer, and the p=11
+non-cancelling sublayer.
+
+It is a finite diagnostic. It does not prove RH, GRH, an asymptotic packet law,
+or an unconditional variance bound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+from tools.check_p11_partial_orbit_packet import packet_energy_row
+
+OLD_LAYER_COUNT = 47
+P11_CANCELLING_COUNT = 240
+P11_NONCANCELLING_COUNT = 192
+
+
+@dataclass(frozen=True)
+class NormalizedPacketEnergyRow:
+    depth: int
+    old_layer_energy_per_character: float
+    p11_cancelling_energy_per_character: float
+    p11_noncancelling_energy_per_character: float
+    noncancel_to_cancel_ratio: float
+    noncancel_to_old_ratio: float
+    cancel_to_old_ratio: float
+
+
+def normalized_packet_energy_row(depth: int) -> NormalizedPacketEnergyRow:
+    row = packet_energy_row(depth)
+    old_per = row.old_p210_energy / OLD_LAYER_COUNT
+    cancel_per = row.p11_cancelling_energy / P11_CANCELLING_COUNT
+    noncancel_per = row.p11_noncancelling_energy / P11_NONCANCELLING_COUNT
+    return NormalizedPacketEnergyRow(
+        depth=depth,
+        old_layer_energy_per_character=old_per,
+        p11_cancelling_energy_per_character=cancel_per,
+        p11_noncancelling_energy_per_character=noncancel_per,
+        noncancel_to_cancel_ratio=noncancel_per / cancel_per,
+        noncancel_to_old_ratio=noncancel_per / old_per,
+        cancel_to_old_ratio=cancel_per / old_per,
+    )
+
+
+def normalized_packet_energy_rows(depths: Iterable[int] = (2, 3, 4)) -> Tuple[NormalizedPacketEnergyRow, ...]:
+    return tuple(normalized_packet_energy_row(depth) for depth in depths)
+
+
+def run_checks() -> Tuple[NormalizedPacketEnergyRow, ...]:
+    rows = normalized_packet_energy_rows()
+    for row in rows:
+        if row.old_layer_energy_per_character <= 0:
+            raise AssertionError(row)
+        if row.p11_cancelling_energy_per_character <= 0:
+            raise AssertionError(row)
+        if row.p11_noncancelling_energy_per_character <= 0:
+            raise AssertionError(row)
+        if row.noncancel_to_cancel_ratio <= 0:
+            raise AssertionError(row)
+    if abs(rows[0].noncancel_to_cancel_ratio - 1.0) > 1e-12:
+        raise AssertionError(rows[0])
+    if rows[1].noncancel_to_cancel_ratio <= 1.0:
+        raise AssertionError(rows[1])
+    if rows[2].noncancel_to_cancel_ratio <= rows[1].noncancel_to_cancel_ratio:
+        raise AssertionError(rows[2])
+    return rows
+
+
+def main() -> None:
+    print("Count-normalized packet-energy diagnostic")
+    for row in run_checks():
+        print(
+            f"K={row.depth} old_per={row.old_layer_energy_per_character:.12f} "
+            f"p11_cancel_per={row.p11_cancelling_energy_per_character:.12f} "
+            f"p11_non_per={row.p11_noncancelling_energy_per_character:.12f} "
+            f"non/cancel={row.noncancel_to_cancel_ratio:.12f} "
+            f"non/old={row.noncancel_to_old_ratio:.12f} "
+            f"cancel/old={row.cancel_to_old_ratio:.12f}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds HW-PRIME-WEIL-011, a count-normalized packet-energy diagnostic.

Files:

- `docs/prime-operator-lane/HW-PRIME-WEIL-011-renormalized-packet-energy.md`
- `tools/check_renormalized_packet_energy.py`
- `tests/test_renormalized_packet_energy.py`

## Claim posture

Finite diagnostic only. It removes raw character-count growth by comparing energy per character across the old P=210 layer, p=11 cancelling sublayer, and p=11 non-cancelling sublayer. No theorem promotion.

## STOP gate

Opened for review only. Do not merge until reviewed.