### PR TITLE
prime-weil: add HW-PRIME-WEIL-012 unified packet normalization

### DIFF
--- a/docs/prime-operator-lane/HW-PRIME-WEIL-012-unified-packet-normalization.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-012-unified-packet-normalization.md
@@ -1,0 +1,126 @@
+# HW-PRIME-WEIL-012 — Unified Count-Normalized Packet Comparison
+
+Status: finite diagnostic surface.  
+Claim class: finite computation / orbit-class energy-per-character comparison, not theorem-grade analytic progress.  
+Lane: prime/operator lane, primorial tower variance decomposition.  
+Depends on: `HW-PRIME-WEIL-007`, `HW-PRIME-WEIL-009`, `HW-PRIME-WEIL-010`, `HW-PRIME-WEIL-011`, `HW-OPEN-011`.
+
+## Purpose
+
+This document compares count-normalized character energy across all orbit classes visible at the `P=2310` level.
+
+The goal is to remove raw character-count dilution and test whether orbit type remains visible in energy per character.
+
+## Packet classes
+
+At `P=2310`, split the nontrivial character family into four finite classes:
+
+| Packet | Count | Orbit type |
+|---|---:|---|
+| `inert_p235` | `7` | terminating / degenerate layer from `p=2,3,5` |
+| `p7_full` | `40` | full-orbit `p=7` layer inherited from `P=210` |
+| `p11_cancel` | `240` | `p=11` partial-orbit cancelling sublayer |
+| `p11_noncancel` | `192` | `p=11` partial-orbit non-cancelling sublayer |
+
+The total is:
+
+```text
+7 + 40 + 240 + 192 = 479
+```
+
+which is the full nontrivial character count for `P=2310`.
+
+## Statistic
+
+For packet `C`, define:
+
+```text
+E_C(K) = (sum_{chi in C} |psi_{W_K}(chi)|^2) / |C|.
+```
+
+This is energy per character.
+
+This statistic suppresses raw layer size and makes orbit-quality effects visible at finite depth.
+
+## Finite measured values
+
+| K | inert `p=2,3,5` | `p=7` full orbit | `p=11` cancelling | `p=11` non-cancelling |
+|---:|---:|---:|---:|---:|
+| 2 | `43.975485786919` | `202.301568265311` | `295.278465033670` | `295.278465033670` |
+| 3 | `912.628197074576` | `1575.759657835338` | `3923.097663316467` | `4214.224918349286` |
+| 4 | `881.487346082066` | `12236.765876957472` | `31698.312041391291` | `37149.288448317449` |
+
+## Observed finite ordering
+
+At `K=2`:
+
+```text
+inert < p7_full < p11_cancel = p11_noncancel.
+```
+
+At `K=3,4`:
+
+```text
+inert < p7_full < p11_cancel < p11_noncancel.
+```
+
+Thus the finite data support the packet-energy stratification:
+
+```text
+terminating/degenerate < full-orbit < partial cancelling < partial non-cancelling
+```
+
+at the tested depths.
+
+This is a finite diagnostic statement only.
+
+## Ratios
+
+The diagnostic computes the following ratios:
+
+| K | `p7_full / inert` | `p11_cancel / p7_full` | `p11_non / p11_cancel` |
+|---:|---:|---:|---:|
+| 2 | `4.600323666511` | `1.459595533655` | `1.000000000000` |
+| 3 | `1.726615149670` | `2.489654870390` | `1.074208515825` |
+| 4 | `13.881955044937` | `2.590415322906` | `1.171964248437` |
+
+The `p11_non / p11_cancel` ratio is exactly `1` at `K=2`, then increases at the next two tested depths.
+
+## Interpretation
+
+The count-normalized statistic separates two effects:
+
+1. raw character-count growth across primorial levels;
+2. orbit-quality energy concentration within a fixed finite character family.
+
+After count normalization, the `p=11` non-cancelling sublayer still carries more energy per character than the `p=11` cancelling sublayer at `K=3,4`.
+
+The full-orbit `p=7` layer sits above the inert `p=2,3,5` layer and below the `p=11` partial-orbit layers in the tested windows.
+
+This suggests that orbit type is visible after removing raw character-count growth, but no asymptotic ordering is claimed.
+
+## Boundary
+
+This is a finite computation over `P=2310` and small Richter depths.
+
+It does not prove that this ordering persists for all depths.
+
+It does not prove that the ordering persists at later primorial levels.
+
+It does not prove that orbit classification alone determines energy-per-character asymptotics.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove Artin's conjecture.
+
+This document does not prove an unconditional variance bound.
+
+This document does not prove an asymptotic packet-energy ordering.
+
+This document does not prove that non-cancelling partial-orbit characters always carry more energy per character.
+
+This document does not close the square-root barrier.

--- a/tests/test_unified_packet_normalization.py
+++ b/tests/test_unified_packet_normalization.py
@@ -1,0 +1,67 @@
+import unittest
+
+from tools.check_unified_packet_normalization import (
+    PACKET_COUNTS,
+    energy_per_character,
+    run_checks,
+    unified_packet_row,
+)
+
+
+class TestUnifiedPacketNormalization(unittest.TestCase):
+    def test_packet_counts_partition_nontrivial_family(self) -> None:
+        self.assertEqual(PACKET_COUNTS["inert_p235"], 7)
+        self.assertEqual(PACKET_COUNTS["p7_full"], 40)
+        self.assertEqual(PACKET_COUNTS["p11_cancel"], 240)
+        self.assertEqual(PACKET_COUNTS["p11_noncancel"], 192)
+        self.assertEqual(sum(PACKET_COUNTS.values()), 479)
+
+    def test_run_checks(self) -> None:
+        rows = run_checks()
+        self.assertEqual([row.depth for row in rows], [2, 3, 4])
+
+    def test_depth_2_values(self) -> None:
+        per = energy_per_character(2)
+        self.assertAlmostEqual(per["inert_p235"], 43.97548578691933, places=12)
+        self.assertAlmostEqual(per["p7_full"], 202.30156826531112, places=12)
+        self.assertAlmostEqual(per["p11_cancel"], 295.27846503367005, places=12)
+        self.assertAlmostEqual(per["p11_noncancel"], 295.27846503367033, places=12)
+
+    def test_depth_3_values(self) -> None:
+        per = energy_per_character(3)
+        self.assertAlmostEqual(per["inert_p235"], 912.6281970745762, places=12)
+        self.assertAlmostEqual(per["p7_full"], 1575.7596578353377, places=12)
+        self.assertAlmostEqual(per["p11_cancel"], 3923.0976633164673, places=12)
+        self.assertAlmostEqual(per["p11_noncancel"], 4214.224918349286, places=12)
+
+    def test_depth_4_values(self) -> None:
+        per = energy_per_character(4)
+        self.assertAlmostEqual(per["inert_p235"], 881.487346082066, places=12)
+        self.assertAlmostEqual(per["p7_full"], 12236.765876957472, places=12)
+        self.assertAlmostEqual(per["p11_cancel"], 31698.31204139129, places=12)
+        self.assertAlmostEqual(per["p11_noncancel"], 37149.28844831745, places=12)
+
+    def test_observed_ordering(self) -> None:
+        for depth in (2, 3, 4):
+            row = unified_packet_row(depth)
+            self.assertLess(row.inert_p235_per_character, row.p7_full_per_character)
+            self.assertLess(row.p7_full_per_character, row.p11_cancel_per_character)
+            self.assertLessEqual(row.p11_cancel_per_character, row.p11_noncancel_per_character + 1e-9)
+        self.assertAlmostEqual(unified_packet_row(2).p11_noncancel_over_p11_cancel, 1.0, places=12)
+        self.assertGreater(unified_packet_row(3).p11_noncancel_over_p11_cancel, 1.0)
+        self.assertGreater(
+            unified_packet_row(4).p11_noncancel_over_p11_cancel,
+            unified_packet_row(3).p11_noncancel_over_p11_cancel,
+        )
+
+    def test_claim_is_finite_diagnostic_only(self) -> None:
+        proves_grh = False
+        proves_asymptotic_ordering = False
+        proves_unconditional_variance_bound = False
+        self.assertFalse(proves_grh)
+        self.assertFalse(proves_asymptotic_ordering)
+        self.assertFalse(proves_unconditional_variance_bound)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_unified_packet_normalization.py
+++ b/tools/check_unified_packet_normalization.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Unified count-normalized packet comparison for P=2310.
+
+This diagnostic splits the P=2310 nontrivial character family into four
+finite orbit classes:
+
+1. inert/terminating/degenerate p=2,3,5 layer;
+2. p=7 full-orbit layer;
+3. p=11 partial-orbit cancelling layer;
+4. p=11 partial-orbit non-cancelling layer.
+
+It reports energy per character for each class. This is a finite diagnostic,
+not an asymptotic theorem and not RH/GRH progress.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+from tools.check_p11_partial_orbit_packet import character_indices, window_character_sum
+
+PACKET_ORDER = ("inert_p235", "p7_full", "p11_cancel", "p11_noncancel")
+PACKET_LABELS = {
+    "inert_p235": "p=2,3,5 inert/degenerate layer",
+    "p7_full": "p=7 full-orbit layer",
+    "p11_cancel": "p=11 partial-orbit cancelling layer",
+    "p11_noncancel": "p=11 partial-orbit non-cancelling layer",
+}
+PACKET_COUNTS = {
+    "inert_p235": 7,
+    "p7_full": 40,
+    "p11_cancel": 240,
+    "p11_noncancel": 192,
+}
+
+
+@dataclass(frozen=True)
+class UnifiedPacketRow:
+    depth: int
+    inert_p235_per_character: float
+    p7_full_per_character: float
+    p11_cancel_per_character: float
+    p11_noncancel_per_character: float
+    p7_over_inert: float
+    p11_cancel_over_p7: float
+    p11_noncancel_over_p11_cancel: float
+
+
+def classify_index(index: Tuple[int, int, int, int]) -> str:
+    e3, e5, e7, e11 = index
+    if index == (0, 0, 0, 0):
+        return "trivial"
+    if e11 != 0:
+        return "p11_noncancel" if e11 % 2 == 0 else "p11_cancel"
+    if e7 != 0:
+        return "p7_full"
+    return "inert_p235"
+
+
+def packet_energies(depth: int) -> Dict[str, float]:
+    energies = {name: 0.0 for name in PACKET_ORDER}
+    counts = {name: 0 for name in PACKET_ORDER}
+    for index in character_indices():
+        packet = classify_index(index)
+        if packet == "trivial":
+            continue
+        energies[packet] += abs(window_character_sum(index, depth)) ** 2
+        counts[packet] += 1
+    if counts != PACKET_COUNTS:
+        raise AssertionError((counts, PACKET_COUNTS))
+    return energies
+
+
+def energy_per_character(depth: int) -> Dict[str, float]:
+    energies = packet_energies(depth)
+    return {packet: energies[packet] / PACKET_COUNTS[packet] for packet in PACKET_ORDER}
+
+
+def unified_packet_row(depth: int) -> UnifiedPacketRow:
+    per = energy_per_character(depth)
+    return UnifiedPacketRow(
+        depth=depth,
+        inert_p235_per_character=per["inert_p235"],
+        p7_full_per_character=per["p7_full"],
+        p11_cancel_per_character=per["p11_cancel"],
+        p11_noncancel_per_character=per["p11_noncancel"],
+        p7_over_inert=per["p7_full"] / per["inert_p235"],
+        p11_cancel_over_p7=per["p11_cancel"] / per["p7_full"],
+        p11_noncancel_over_p11_cancel=per["p11_noncancel"] / per["p11_cancel"],
+    )
+
+
+def unified_packet_rows(depths: Iterable[int] = (2, 3, 4)) -> Tuple[UnifiedPacketRow, ...]:
+    return tuple(unified_packet_row(depth) for depth in depths)
+
+
+def run_checks() -> Tuple[UnifiedPacketRow, ...]:
+    rows = unified_packet_rows()
+    for row in rows:
+        if not (
+            row.inert_p235_per_character
+            < row.p7_full_per_character
+            < row.p11_cancel_per_character
+            <= row.p11_noncancel_per_character + 1e-9
+        ):
+            raise AssertionError(row)
+    if abs(rows[0].p11_noncancel_per_character - rows[0].p11_cancel_per_character) > 1e-9:
+        raise AssertionError(rows[0])
+    if rows[1].p11_noncancel_over_p11_cancel <= 1.0:
+        raise AssertionError(rows[1])
+    if rows[2].p11_noncancel_over_p11_cancel <= rows[1].p11_noncancel_over_p11_cancel:
+        raise AssertionError(rows[2])
+    return rows
+
+
+def main() -> None:
+    print("Unified count-normalized packet comparison")
+    for row in run_checks():
+        print(
+            f"K={row.depth} inert={row.inert_p235_per_character:.12f} "
+            f"p7_full={row.p7_full_per_character:.12f} "
+            f"p11_cancel={row.p11_cancel_per_character:.12f} "
+            f"p11_non={row.p11_noncancel_per_character:.12f} "
+            f"p7/inert={row.p7_over_inert:.12f} "
+            f"cancel/p7={row.p11_cancel_over_p7:.12f} "
+            f"non/cancel={row.p11_noncancel_over_p11_cancel:.12f}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds HW-PRIME-WEIL-012, a unified count-normalized packet comparison for P=2310.

Files:

- `docs/prime-operator-lane/HW-PRIME-WEIL-012-unified-packet-normalization.md`
- `tools/check_unified_packet_normalization.py`
- `tests/test_unified_packet_normalization.py`

## Claim posture

Finite diagnostic only. Compares energy per character across inert p=2,3,5, p=7 full-orbit, p=11 cancelling, and p=11 non-cancelling packets. No RH/GRH proof, no unconditional variance bound, and no asymptotic packet-ordering claim.

## STOP gate

Opened for review only. Do not merge until reviewed.