### PR TITLE
prime-weil: extend HW-PRIME-WEIL-011 to K5 and add detection threshold

### DIFF
--- a/docs/prime-operator-lane/HW-OPEN-012-detection-threshold.md
+++ b/docs/prime-operator-lane/HW-OPEN-012-detection-threshold.md
@@ -1,0 +1,142 @@
+# HW-OPEN-012 — Off-Line Zero Detection Threshold
+
+Status: open diagnostic threshold problem.  
+Claim class: finite-diagnostic / explicit-formula threshold surface, not theorem-grade analytic progress.  
+Lane: prime/operator lane, Richter-window / renormalized packet-energy surface.  
+Depends on: `HW-PRIME-WEIL-005`, `HW-PRIME-WEIL-011`.
+
+## Purpose
+
+This document records the detection-threshold problem exposed by the `K=5` extension of `HW-PRIME-WEIL-011`.
+
+The count-normalized `p=11` cancelling and non-cancelling energies remain bounded after division by `10^K` for the tested depths `K=2,3,4,5`. The non-cancelling/cancelling ratio also inverts at `K=5`, showing finite prime-race fluctuation rather than monotone growth.
+
+This is consistent with GRH-scale behavior at the tested depths. It is not evidence for RH or GRH, and it is not evidence against a hypothetical off-line zero at depths beyond current computation.
+
+## Observed finite scale
+
+For the `p=11` cancelling and non-cancelling sublayers, the tested values of:
+
+```text
+E_C(K) / 10^K
+```
+
+remain bounded in the finite computed range:
+
+| K | `E_cancel(K)/10^K` | `E_non(K)/10^K` |
+|---:|---:|---:|
+| 2 | `2.952784650337` | `2.952784650337` |
+| 3 | `3.923097663316` | `4.214224918349` |
+| 4 | `3.169831204139` | `3.714928844832` |
+| 5 | `3.578881287026` | `3.051196916722` |
+
+No exponential growth is visible at these depths.
+
+## Ratio inversion
+
+The finite ratio:
+
+```text
+E_non(K) / E_cancel(K)
+```
+
+is:
+
+| K | ratio |
+|---:|---:|
+| 2 | `1.000000000000` |
+| 3 | `1.074208515825` |
+| 4 | `1.171964248437` |
+| 5 | `0.852556056493` |
+
+The inversion at `K=5` is a finite prime-race / residue-bias diagnostic. It shows that the count-normalized p11 sublayer statistic is sensitive to window-level residue fluctuations.
+
+This document does not promote the inversion to a theorem-grade Littlewood or Chebyshev-bias statement.
+
+## Detection-threshold model
+
+A hypothetical off-critical zero with:
+
+```text
+rho = 1/2 + delta + i t,
+```
+
+would contribute a growth factor of the form:
+
+```text
+10^(2 delta K)
+```
+
+to squared-energy scale after normalization by the critical-line baseline.
+
+A crude detectability heuristic compares:
+
+```text
+10^(2 delta K) / K^2
+```
+
+against an `O(1)` finite noise floor.
+
+For example, if:
+
+```text
+delta = 0.1,
+```
+
+then at `K=5`:
+
+```text
+10^(2 delta K) / K^2 = 10^1 / 25 = 0.4,
+```
+
+which remains below an `O(1)` finite diagnostic floor. At `K=20`:
+
+```text
+10^(2 delta K) / K^2 = 10^4 / 400 = 25,
+```
+
+which would exceed such a crude threshold.
+
+This is only a heuristic detection threshold. It is not a theorem and does not account for phase cancellation, zero multiplicity, explicit-formula truncation, or the actual finite variance noise model.
+
+## Computational barrier
+
+Direct prime enumeration to depth `K=20` would require windows up to:
+
+```text
+10^20,
+```
+
+which is infeasible for the present direct enumeration diagnostics.
+
+Thus the next analytic problem is not direct computation, but an explicit-formula surrogate for the renormalized packet-energy statistic at larger depths.
+
+## Open problem
+
+Can the explicit formula be used to estimate or bound the count-normalized packet-energy ratios at depths beyond direct enumeration, while preserving the finite packet decomposition used in `HW-PRIME-WEIL-011`?
+
+Concrete subproblems:
+
+1. derive an explicit-formula expression for the p11 cancelling and non-cancelling packet energies;
+2. quantify the finite noise floor for the normalized packet-energy ratio;
+3. determine the depth at which a hypothetical off-critical contribution of size `delta` would become detectable;
+4. distinguish genuine off-line-zero growth from finite prime-race sign changes;
+5. state a non-circular criterion that does not assume GRH to rule out large-depth growth.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove an off-line zero exists.
+
+This document does not rule out off-line zeros.
+
+This document does not prove a Littlewood sign-change theorem or a Chebyshev-bias theorem.
+
+This document does not prove the explicit-formula surrogate exists.
+
+This document does not prove an unconditional variance bound.
+
+This document does not close the square-root barrier.

--- a/docs/prime-operator-lane/HW-PRIME-WEIL-011-renormalized-packet-energy.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-011-renormalized-packet-energy.md
@@ -50,15 +50,49 @@ chi(10) = +1.
 | 2 | `178.721087896189` | `295.278465033670` | `295.278465033670` | `1.000000000000` | `1.652174729404` |
 | 3 | `1476.995397722033` | `3923.097663316467` | `4214.224918349286` | `1.074208515825` | `2.853241739852` |
 | 4 | `10545.554180869645` | `31698.312041391290` | `37149.288448317450` | `1.171964248437` | `3.522744069317` |
+| 5 | `136843.171318387579` | `357888.128702571034` | `305119.691672236600` | `0.852556056493` | `2.229703453469` |
 
-The finite data show:
+The finite data now show:
 
 ```text
 E_p11_non(K) = E_p11_cancel(K) at K=2,
-E_p11_non(K) > E_p11_cancel(K) for K=3,4.
+E_p11_non(K) > E_p11_cancel(K) for K=3,4,
+E_p11_non(K) < E_p11_cancel(K) at K=5.
 ```
 
-The gap between non-cancelling and cancelling p=11 sublayers grows across the computed depths.
+Thus the p=11 cancelling/non-cancelling ratio is not monotone across the tested windows.
+
+## Scale-normalized p11 values
+
+Divide by `10^K` to compare finite energy-per-character scale across depths.
+
+| K | `E_p11_cancel(K) / 10^K` | `E_p11_non(K) / 10^K` |
+|---:|---:|---:|
+| 2 | `2.952784650337` | `2.952784650337` |
+| 3 | `3.923097663316` | `4.214224918349` |
+| 4 | `3.169831204139` | `3.714928844832` |
+| 5 | `3.578881287026` | `3.051196916722` |
+
+Both p11 sublayers remain bounded in the tested range after division by `10^K`. This is consistent with GRH-scale finite behavior and does not display exponential growth.
+
+## Ratio inversion / prime-race diagnostic
+
+The ratio:
+
+```text
+E_p11_non(K) / E_p11_cancel(K)
+```
+
+rises through `K=4` and then inverts at `K=5`:
+
+```text
+K=2: 1.000000000000
+K=3: 1.074208515825
+K=4: 1.171964248437
+K=5: 0.852556056493
+```
+
+This finite inversion is a prime-race / residue-bias diagnostic. It is consistent with the general expectation that residue-class prime biases can change sign across ranges, but this document does not promote that observation into a theorem-grade Littlewood/Chebyshev-bias statement.
 
 ## Interpretation
 
@@ -80,13 +114,31 @@ chi(10)=-1,
 
 Count-normalized energy therefore separates orbit-quality effects from raw packet size.
 
-The finite observed ordering is:
+The finite observed ordering is window-dependent:
 
 ```text
 p11 non-cancelling >= p11 cancelling > old P=210 layer
 ```
 
-for the computed windows, with equality between the two p=11 sublayers at `K=2`.
+for `K=2,3,4`, with equality between the two p=11 sublayers at `K=2`, but:
+
+```text
+p11 cancelling > p11 non-cancelling > old P=210 layer
+```
+
+at `K=5`.
+
+This sign-change behavior is evidence that the statistic is sensitive to finite prime-race fluctuations, not a monotone orbit-quality invariant.
+
+## Detection threshold context
+
+The absence of exponential growth at `K<=5` is not evidence against an off-critical zero in any theorem-grade sense. A hypothetical off-line contribution with small `delta` may be below the finite diagnostic noise floor at these depths.
+
+The associated detection-threshold problem is recorded in:
+
+```text
+HW-OPEN-012
+```
 
 ## Boundary
 
@@ -98,12 +150,15 @@ It does not prove that local orbit type alone determines energy per character.
 
 It does not prove that prime-window energy follows local character-count or local cancellation baselines at large depths.
 
+It does not prove a theorem-grade Chebyshev-bias sign-change result.
+
 ## Next questions
 
-1. Does `E_p11_non(K) / E_p11_cancel(K)` continue increasing at deeper feasible depths?
+1. Does `E_p11_non(K) / E_p11_cancel(K)` continue oscillating around `1` at deeper feasible depths?
 2. Does the same count-normalized separation appear for later partial-orbit primes?
 3. Do full-orbit Artin packets have lower energy per character after count normalization?
 4. Is there a stable normalized statistic that preserves orbit quality across primorial extensions?
+5. What depth is required before a hypothetical off-critical contribution would exceed the finite diagnostic noise floor?
 
 ## Non-claims
 
@@ -118,5 +173,7 @@ This document does not prove an unconditional variance bound.
 This document does not prove an asymptotic packet-energy ordering.
 
 This document does not prove that non-cancelling partial-orbit characters always carry more energy per character.
+
+This document does not prove a Littlewood sign-change theorem or a Chebyshev-bias theorem.
 
 This document does not close the square-root barrier.

--- a/tests/test_detection_threshold.py
+++ b/tests/test_detection_threshold.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "prime-operator-lane" / "HW-OPEN-012-detection-threshold.md"
+
+
+class TestDetectionThreshold(unittest.TestCase):
+    def test_document_exists_and_is_open_problem(self) -> None:
+        self.assertTrue(DOC.exists())
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("HW-OPEN-012", text)
+        self.assertIn("open diagnostic threshold problem", text)
+        self.assertIn("explicit-formula threshold surface", text)
+
+    def test_finite_scale_values_are_recorded(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "2.952784650337",
+            "3.923097663316",
+            "3.169831204139",
+            "3.578881287026",
+            "3.051196916722",
+        ]:
+            self.assertIn(token, text)
+
+    def test_ratio_inversion_values_are_recorded(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "1.000000000000",
+            "1.074208515825",
+            "1.171964248437",
+            "0.852556056493",
+        ]:
+            self.assertIn(token, text)
+
+    def test_detection_threshold_heuristic_is_bounded(self) -> None:
+        delta = 0.1
+        current_depths = (2, 3, 4, 5)
+        for depth in current_depths:
+            off_line_signal = 10 ** (2 * delta * depth) / (depth**2)
+            self.assertLess(off_line_signal, 1.0)
+        detectable_depth = 20
+        self.assertGreater(10 ** (2 * delta * detectable_depth) / (detectable_depth**2), 1.0)
+        self.assertGreater(detectable_depth, max(current_depths))
+
+    def test_non_claims_are_present(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "does not prove RH",
+            "does not prove GRH",
+            "does not rule out off-line zeros",
+            "does not prove the explicit-formula surrogate exists",
+            "does not prove an unconditional variance bound",
+            "does not close the square-root barrier",
+        ]:
+            self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_renormalized_packet_energy.py
+++ b/tests/test_renormalized_packet_energy.py
@@ -17,7 +17,7 @@ class TestRenormalizedPacketEnergy(unittest.TestCase):
 
     def test_run_checks(self) -> None:
         rows = run_checks()
-        self.assertEqual([row.depth for row in rows], [2, 3, 4])
+        self.assertEqual([row.depth for row in rows], [2, 3, 4, 5])
 
     def test_depth_2_values(self) -> None:
         row = normalized_packet_energy_row(2)
@@ -40,19 +40,48 @@ class TestRenormalizedPacketEnergy(unittest.TestCase):
         self.assertAlmostEqual(row.p11_noncancelling_energy_per_character, 37149.28844831745, places=12)
         self.assertAlmostEqual(row.noncancel_to_cancel_ratio, 1.1719642484372144, places=12)
 
-    def test_non_cancelling_ratio_increases_after_depth_2(self) -> None:
-        rows = run_checks()
-        self.assertAlmostEqual(rows[0].noncancel_to_cancel_ratio, 1.0, places=12)
-        self.assertGreater(rows[1].noncancel_to_cancel_ratio, rows[0].noncancel_to_cancel_ratio)
-        self.assertGreater(rows[2].noncancel_to_cancel_ratio, rows[1].noncancel_to_cancel_ratio)
+    def test_depth_5_values(self) -> None:
+        row = normalized_packet_energy_row(5)
+        self.assertAlmostEqual(row.old_layer_energy_per_character, 136843.17131838758, places=12)
+        self.assertAlmostEqual(row.p11_cancelling_energy_per_character, 357888.12870257103, places=12)
+        self.assertAlmostEqual(row.p11_noncancelling_energy_per_character, 305119.6916722366, places=12)
+        self.assertAlmostEqual(row.noncancel_to_cancel_ratio, 0.8525560564927581, places=12)
+
+    def test_ratio_oscillates_not_monotone(self) -> None:
+        ratios = {depth: normalized_packet_energy_row(depth).noncancel_to_cancel_ratio for depth in (2, 3, 4, 5)}
+        self.assertAlmostEqual(ratios[2], 1.0, places=12)
+        self.assertGreater(ratios[3], ratios[2])
+        self.assertGreater(ratios[4], ratios[3])
+        self.assertLess(ratios[5], ratios[4])
+        self.assertLess(ratios[5], 1.0)
+
+    def test_energy_per_10K_bounded(self) -> None:
+        for depth in (2, 3, 4, 5):
+            row = normalized_packet_energy_row(depth)
+            cancel_scaled = row.p11_cancelling_energy_per_character / (10**depth)
+            noncancel_scaled = row.p11_noncancelling_energy_per_character / (10**depth)
+            self.assertLess(cancel_scaled, 6.0)
+            self.assertLess(noncancel_scaled, 6.0)
+
+    def test_no_exponential_growth_detected_at_current_depths(self) -> None:
+        # This is a finite diagnostic non-claim. For a small off-line offset, a
+        # simple signal-to-baseline heuristic remains below the current compute range.
+        delta_test = 0.1
+        for depth in (2, 3, 4, 5):
+            off_line_signal = 10 ** (2 * delta_test * depth) / (depth**2)
+            self.assertLess(off_line_signal, 1.0)
+        conservative_detectable_depth = 20
+        self.assertGreater(conservative_detectable_depth, 5)
 
     def test_claim_is_finite_diagnostic_only(self) -> None:
         proves_grh = False
         proves_asymptotic_ordering = False
         proves_unconditional_variance_bound = False
+        proves_littlewood_theorem = False
         self.assertFalse(proves_grh)
         self.assertFalse(proves_asymptotic_ordering)
         self.assertFalse(proves_unconditional_variance_bound)
+        self.assertFalse(proves_littlewood_theorem)
 
 
 if __name__ == "__main__":

--- a/tools/check_renormalized_packet_energy.py
+++ b/tools/check_renormalized_packet_energy.py
@@ -48,7 +48,7 @@ def normalized_packet_energy_row(depth: int) -> NormalizedPacketEnergyRow:
     )
 
 
-def normalized_packet_energy_rows(depths: Iterable[int] = (2, 3, 4)) -> Tuple[NormalizedPacketEnergyRow, ...]:
+def normalized_packet_energy_rows(depths: Iterable[int] = (2, 3, 4, 5)) -> Tuple[NormalizedPacketEnergyRow, ...]:
     return tuple(normalized_packet_energy_row(depth) for depth in depths)
 
 
@@ -69,19 +69,26 @@ def run_checks() -> Tuple[NormalizedPacketEnergyRow, ...]:
         raise AssertionError(rows[1])
     if rows[2].noncancel_to_cancel_ratio <= rows[1].noncancel_to_cancel_ratio:
         raise AssertionError(rows[2])
+    if rows[3].noncancel_to_cancel_ratio >= rows[2].noncancel_to_cancel_ratio:
+        raise AssertionError(rows[3])
+    if rows[3].noncancel_to_cancel_ratio >= 1.0:
+        raise AssertionError(rows[3])
     return rows
 
 
 def main() -> None:
     print("Count-normalized packet-energy diagnostic")
     for row in run_checks():
+        cancel_scaled = row.p11_cancelling_energy_per_character / (10**row.depth)
+        noncancel_scaled = row.p11_noncancelling_energy_per_character / (10**row.depth)
         print(
             f"K={row.depth} old_per={row.old_layer_energy_per_character:.12f} "
             f"p11_cancel_per={row.p11_cancelling_energy_per_character:.12f} "
             f"p11_non_per={row.p11_noncancelling_energy_per_character:.12f} "
             f"non/cancel={row.noncancel_to_cancel_ratio:.12f} "
             f"non/old={row.noncancel_to_old_ratio:.12f} "
-            f"cancel/old={row.cancel_to_old_ratio:.12f}"
+            f"cancel/old={row.cancel_to_old_ratio:.12f} "
+            f"cancel/10^K={cancel_scaled:.12f} non/10^K={noncancel_scaled:.12f}"
         )
 
 


### PR DESCRIPTION
## Summary

Extends HW-PRIME-WEIL-011 to K=5 and adds HW-OPEN-012 for the off-line-zero detection-threshold problem.

Files:

- `docs/prime-operator-lane/HW-PRIME-WEIL-011-renormalized-packet-energy.md`
- `docs/prime-operator-lane/HW-OPEN-012-detection-threshold.md`
- `tools/check_renormalized_packet_energy.py`
- `tests/test_renormalized_packet_energy.py`
- `tests/test_detection_threshold.py`

## Claim posture

Finite diagnostic and open threshold problem only. Records the K=5 p11 ratio inversion and bounded E/10^K scale. No RH/GRH proof, no off-line-zero exclusion, no Littlewood theorem proof, and no unconditional variance bound.

## STOP gate

Opened for review only. Do not merge until reviewed.