### PR TITLE
prime-weil: add HW-PRIME-WEIL-015 q37 orbit-quality measurement

### DIFF
--- a/docs/prime-operator-lane/HW-PRIME-WEIL-015-q37-orbit-quality-measurement.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-015-q37-orbit-quality-measurement.md
@@ -1,0 +1,125 @@
+# HW-PRIME-WEIL-015 — q=37 Orbit-Quality Measurement
+
+Status: finite measurement / model-falsification surface.  
+Claim class: finite diagnostic result, not theorem-grade analytic progress.  
+Lane: prime/operator lane, orbit-quality / packet-energy surface.  
+Depends on: `HW-OPEN-013`, `HW-PRIME-WEIL-014`.
+
+## Purpose
+
+This document records the first q=37 measurement against the pre-registered orbit-quality model from `HW-OPEN-013`.
+
+The model was fixed before measurement:
+
+```text
+R(q) = 1 + 0.3439 / ord_q(10).
+```
+
+For `q=37`:
+
+```text
+ord_37(10) = 3,
+R(37) = 1.114633333333...
+```
+
+The measurement below uses local conductor-37 character packets, not the full primorial-through-37 character family.
+
+## q=37 packet structure
+
+For `q=37`:
+
+```text
+ord_37(10) = 3,
+I_37 = (37-1)/3 = 12,
+n_nc(37) = 11.
+```
+
+There are:
+
+```text
+11 non-cancelling local characters,
+24 cancelling local characters.
+```
+
+The measured statistic is:
+
+```text
+R_meas(37,K) = E_nc(37,K) / E_cancel(37,K),
+```
+
+where each energy is count-normalized by the number of characters in the local packet.
+
+## Pre-registered prediction
+
+The pre-registered prediction was:
+
+```text
+R(37) = 1.114633333333...
+```
+
+No parameter was changed after the measurement.
+
+## Finite measured values
+
+| K | prime count in W_K | E_cancel / char | E_nc / char | measured ratio | deviation from model |
+|---:|---:|---:|---:|---:|---:|
+| 2 | 21 | `189.490278757736` | `114.729033668758` | `0.605461316649` | `-0.509172016685` |
+| 3 | 143 | `1024.158836091167` | `1848.829699483743` | `1.805217739994` | `0.690584406661` |
+| 4 | 1061 | `20069.659764608412` | `9407.435842493238` | `0.468739179081` | `-0.645894154253` |
+| 5 | 8363 | `150781.374888863530` | `103834.737638151404` | `0.688644321719` | `-0.425989011615` |
+
+The measured ratios oscillate strongly and do not stay near the pre-registered prediction in the tested windows.
+
+## Result
+
+The direct local q=37 packet measurement falsifies the pre-registered model in its finite-depth form.
+
+Specifically, the deepest tested value is:
+
+```text
+R_meas(37,5) = 0.688644321719,
+```
+
+which is far below:
+
+```text
+R(37) = 1.114633333333.
+```
+
+This does not refute any theorem. It refines the diagnostic program: orbit period alone is not sufficient to predict finite-depth non-cancelling/cancelling energy ratios.
+
+## Interpretation
+
+The q=37 measurement shows that finite-window prime-race fluctuations dominate the simple `1 + c/d_q` model at the tested depths.
+
+The result does not imply that orbit quality is irrelevant. It implies that the model must include additional structure, such as:
+
+1. coset mass imbalance at the tested window;
+2. prime-race fluctuation across cosets of `<10>`;
+3. depth dependence;
+4. conductor dependence;
+5. interaction between local character parity and the observed window.
+
+## Boundary
+
+This is a local conductor-37 diagnostic.
+
+It is not a full primorial-through-37 computation. The full primorial character family is much larger and requires separate machinery.
+
+The measurement does not prove or disprove RH, GRH, Artin's conjecture, or any asymptotic variance law.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove Artin's conjecture.
+
+This document does not prove an unconditional variance bound.
+
+This document does not prove an asymptotic orbit-quality energy law.
+
+This document does not prove that orbit quality is irrelevant.
+
+This document does not close the square-root barrier.

--- a/tests/test_q37_orbit_quality_measurement.py
+++ b/tests/test_q37_orbit_quality_measurement.py
@@ -1,0 +1,52 @@
+import unittest
+
+from tools.check_q37_orbit_quality_measurement import (
+    cancelling_exponents,
+    noncancelling_exponents,
+    predicted_ratio,
+    q37_row,
+    run_checks,
+)
+
+
+class TestQ37OrbitQualityMeasurement(unittest.TestCase):
+    def test_run_checks(self) -> None:
+        rows = run_checks()
+        self.assertEqual([row.depth for row in rows], [2, 3, 4, 5])
+
+    def test_packet_counts(self) -> None:
+        self.assertEqual(len(noncancelling_exponents()), 11)
+        self.assertEqual(len(cancelling_exponents()), 24)
+
+    def test_preregistered_prediction(self) -> None:
+        self.assertAlmostEqual(predicted_ratio(), 1.1146333333333333, places=12)
+
+    def test_measured_values(self) -> None:
+        expected = {
+            2: (189.49027875773587, 114.7290336687584, 0.6054613166485441),
+            3: (1024.1588360911671, 1848.8296994837428, 1.805217739994352),
+            4: (20069.659764608412, 9407.435842493238, 0.4687391790807865),
+            5: (150781.37488886353, 103834.7376381514, 0.6886443217186798),
+        }
+        for depth, (cancel, noncancel, ratio) in expected.items():
+            row = q37_row(depth)
+            self.assertAlmostEqual(row.cancel_per_character, cancel, places=12)
+            self.assertAlmostEqual(row.noncancel_per_character, noncancel, places=12)
+            self.assertAlmostEqual(row.ratio, ratio, places=12)
+
+    def test_model_is_falsified_at_finite_depths(self) -> None:
+        row = q37_row(5)
+        self.assertLess(row.ratio, 1.0)
+        self.assertGreater(abs(row.ratio - predicted_ratio()), 0.1)
+
+    def test_claim_is_finite_diagnostic_only(self) -> None:
+        proves_grh = False
+        proves_asymptotic_law = False
+        proves_orbit_quality_irrelevant = False
+        self.assertFalse(proves_grh)
+        self.assertFalse(proves_asymptotic_law)
+        self.assertFalse(proves_orbit_quality_irrelevant)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_q37_orbit_quality_measurement.py
+++ b/tools/check_q37_orbit_quality_measurement.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Dict, Iterable, Tuple
+
+Q = 37
+GENERATOR = 2
+MODEL_CONSTANT = 0.3439
+
+
+@dataclass(frozen=True)
+class Q37Row:
+    depth: int
+    prime_count: int
+    cancel_per_character: float
+    noncancel_per_character: float
+    ratio: float
+    predicted_ratio: float
+    deviation: float
+
+
+def predicted_ratio(q: int = Q) -> float:
+    return 1.0 + MODEL_CONSTANT / ord10(q)
+
+
+def ord10(q: int) -> int:
+    x = 1
+    for k in range(1, q):
+        x = (x * 10) % q
+        if x == 1:
+            return k
+    raise RuntimeError(q)
+
+
+@lru_cache(maxsize=None)
+def primes_upto(limit: int) -> Tuple[int, ...]:
+    sieve = bytearray(b"\x01") * (limit + 1)
+    sieve[0:2] = b"\x00\x00"
+    for p in range(2, int(limit**0.5) + 1):
+        if sieve[p]:
+            start = p * p
+            sieve[start : limit + 1 : p] = b"\x00" * (((limit - start) // p) + 1)
+    return tuple(i for i in range(limit + 1) if sieve[i])
+
+
+@lru_cache(maxsize=None)
+def primes_in_window(depth: int) -> Tuple[int, ...]:
+    low = 10 ** (depth - 1)
+    high = 10**depth
+    return tuple(p for p in primes_upto(high - 1) if low <= p < high)
+
+
+@lru_cache(maxsize=None)
+def dlog_table(q: int = Q, generator: int = GENERATOR) -> Dict[int, int]:
+    table: Dict[int, int] = {}
+    value = 1
+    for exponent in range(q - 1):
+        table[value] = exponent
+        value = (value * generator) % q
+    if len(table) != q - 1:
+        raise RuntimeError("generator did not generate unit group")
+    return table
+
+
+def chi_value(exponent: int, residue: int, q: int = Q) -> complex:
+    r = residue % q
+    if r == 0:
+        return 0j
+    k = dlog_table(q)[r]
+    return cmath.exp(2j * math.pi * exponent * k / (q - 1))
+
+
+def noncancelling_exponents(q: int = Q) -> Tuple[int, ...]:
+    return tuple(e for e in range(1, q - 1) if abs(chi_value(e, 10, q) - 1) < 1e-9)
+
+
+def cancelling_exponents(q: int = Q) -> Tuple[int, ...]:
+    nc = set(noncancelling_exponents(q))
+    return tuple(e for e in range(1, q - 1) if e not in nc)
+
+
+def character_sum(exponent: int, depth: int, q: int = Q) -> complex:
+    return sum(math.log(p) * chi_value(exponent, p, q) for p in primes_in_window(depth) if p % q)
+
+
+def q37_row(depth: int) -> Q37Row:
+    cancel = cancelling_exponents(Q)
+    noncancel = noncancelling_exponents(Q)
+    cancel_energy = sum(abs(character_sum(e, depth)) ** 2 for e in cancel) / len(cancel)
+    noncancel_energy = sum(abs(character_sum(e, depth)) ** 2 for e in noncancel) / len(noncancel)
+    pred = predicted_ratio(Q)
+    ratio = noncancel_energy / cancel_energy
+    return Q37Row(
+        depth=depth,
+        prime_count=len(primes_in_window(depth)),
+        cancel_per_character=cancel_energy,
+        noncancel_per_character=noncancel_energy,
+        ratio=ratio,
+        predicted_ratio=pred,
+        deviation=ratio - pred,
+    )
+
+
+def q37_rows(depths: Iterable[int] = (2, 3, 4, 5)) -> Tuple[Q37Row, ...]:
+    return tuple(q37_row(depth) for depth in depths)
+
+
+def run_checks() -> Tuple[Q37Row, ...]:
+    assert ord10(Q) == 3
+    assert len(noncancelling_exponents(Q)) == 11
+    assert len(cancelling_exponents(Q)) == 24
+    rows = q37_rows()
+    assert abs(predicted_ratio(Q) - 1.1146333333333333) < 1e-12
+    assert rows[-1].ratio < 1.0
+    assert abs(rows[-1].ratio - predicted_ratio(Q)) > 0.1
+    return rows
+
+
+if __name__ == "__main__":
+    for row in run_checks():
+        print(row)


### PR DESCRIPTION
Adds HW-PRIME-WEIL-015 as the q=37 measurement against the pre-registered orbit-quality model. Scope: local conductor-37 finite diagnostic only; records model falsification/refinement without RH/GRH proof or asymptotic claim.