### PR TITLE
prime-weil: add HW-OPEN-014 coset variance theorem target

### DIFF
--- a/docs/prime-operator-lane/HW-OPEN-014-coset-variance-theorem-target.md
+++ b/docs/prime-operator-lane/HW-OPEN-014-coset-variance-theorem-target.md
@@ -1,0 +1,151 @@
+# HW-OPEN-014 — Coset Variance Theorem Target
+
+Status: open theorem target / proof-gate surface.  
+Claim class: open analytic theorem target, not theorem-grade progress.  
+Lane: prime/operator lane, coset-variance / packet-energy surface.  
+Depends on: `HW-PRIME-WEIL-014`, `HW-PRIME-WEIL-015`, `HW-OPEN-013`.
+
+## Purpose
+
+This document states the precise coset-variance theorem target exposed by the q=37 measurement.
+
+The q=37 result showed that the first pre-registered orbit-quality model failed as a finite predictor. The corrected problem is not to refit a curve. The corrected problem is to understand the variance of prime mass between and within cosets of the base-10 orbit subgroup.
+
+This is the current native proof gate for the Prime-Weil route.
+
+## Section 1 — Setup
+
+Let `q` be a prime with `gcd(q,10)=1` and define:
+
+```text
+G_q = (Z/qZ)^x,
+H_q = <10> subset G_q,
+d_q = |H_q| = ord_q(10),
+I_q = [G_q : H_q] = (q-1)/d_q.
+```
+
+Let the cosets of `H_q` in `G_q` be:
+
+```text
+C_1, ..., C_{I_q}.
+```
+
+For a Richter window `W_K`, define the residue mass:
+
+```text
+M_K(r) = sum_{p in W_K, p == r mod q} log p.
+```
+
+Define the window coset mass:
+
+```text
+F_K(C_i) = sum_{r in C_i} M_K(r).
+```
+
+The coset masses partition the active prime-log mass:
+
+```text
+sum_i F_K(C_i) = sum_{p in W_K, q not dividing p} log p.
+```
+
+Define between-coset variance:
+
+```text
+Var_between(q,K) = sum_i (F_K(C_i) - mean_C F_K)^2.
+```
+
+Define within-coset variance:
+
+```text
+Var_within(q,K) = sum_i sum_{r in C_i} (M_K(r) - mean_{r in C_i} M_K)^2.
+```
+
+Non-cancelling characters are trivial on `H_q`; they are Fourier modes on the quotient `G_q/H_q` and therefore probe between-coset variance.
+
+Cancelling characters are nontrivial on `H_q`; they probe within-coset structure and cancel over complete base-10 orbits.
+
+## Section 2 — The theorem target
+
+The target is:
+
+```text
+Coset Variance Theorem (target):
+Var_between(q,K) / Var_within(q,K) = O(K^A)
+```
+
+unconditionally as `K -> infinity`, for a fixed exponent `A` in the scoped families.
+
+Under a GRH-shaped square-root model, both variances are expected to live at the critical scale and the ratio should remain polynomially bounded, plausibly approaching a stable range after normalization.
+
+Unconditionally, current methods can allow the between-coset component to be much larger than the within-coset component. The desired theorem would need to show that the quotient coset structure of `<10>` forces enough equidistribution to prevent super-polynomial growth of the ratio.
+
+This is not implied by the finite orbit theorem alone. It requires analytic control of primes in coset unions.
+
+## Section 3 — Proposed attack methods
+
+### Method A — Dispersion method
+
+Apply a dispersion-method / Linnik-style second-moment analysis to prime-counting errors weighted by coset indicators.
+
+Target object:
+
+```text
+sum_i (F_K(C_i) - mean_C F_K)^2.
+```
+
+Current status: classical dispersion methods can produce nontrivial cancellation in some averaged settings, but the fixed-coset, fixed-modulus, Richter-window target still faces the square-root barrier. The expected gap remains a power of the main scale.
+
+### Method B — Large sieve over quotient characters
+
+The quotient group:
+
+```text
+G_q / H_q
+```
+
+has exactly the non-cancelling characters as its nontrivial dual modes.
+
+Apply a large-sieve style bound to quotient characters rather than all characters.
+
+Current status: this correctly isolates the non-cancelling packet, but the large sieve is strongest over varying moduli. For a fixed q-quotient packet, it packages the obstruction rather than closing it.
+
+### Method C — Pretentious character distance
+
+Use Granville-Soundararajan style pretentious distance to measure whether coset indicators correlate with low-complexity characters that create bias.
+
+Current status: the controlling obstruction depends on zeros of the associated Dirichlet L-functions near the critical region. This restates the same GRH-sensitive obstruction in pretentious language.
+
+### Method D — Explicit formula surrogate at small K
+
+Use computationally verified zeros and explicit-formula truncation to estimate the coset variance at finite depths.
+
+Current status: this can certify finite ranges when the required height is within verification bounds. It does not provide an asymptotic proof, and it cannot reach large resonant tower depths with current verification heights.
+
+## Current conclusion
+
+Methods A-D identify the barrier in four languages:
+
+1. dispersion;
+2. quotient-character large sieve;
+3. pretentious distance;
+4. explicit formula truncation.
+
+None currently closes the proof.
+
+The target remains meaningful because it is now exact: prove that between-coset variance cannot outrun within-coset variance faster than a polynomial in `K` without assuming GRH.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove the Coset Variance Theorem.
+
+This document does not prove an unconditional variance bound.
+
+This document does not prove that any of Methods A-D closes the square-root barrier.
+
+This document does not claim that finite q=37 measurements imply asymptotic coset equidistribution.
+
+This document does not close `HW-OPEN-010`, `HW-OPEN-012`, or the square-root barrier identified in `HW-PRIME-WEIL-005`.

--- a/tests/test_coset_variance.py
+++ b/tests/test_coset_variance.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import unittest
+
+from tools.check_coset_variance import (
+    Q,
+    between_coset_variance,
+    coset_masses,
+    coset_variance_row,
+    cosets,
+    residue_masses,
+    run_checks,
+    subgroup_h,
+    theta_active,
+    unit_residues,
+    within_coset_variance,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "prime-operator-lane" / "HW-OPEN-014-coset-variance-theorem-target.md"
+
+
+class TestCosetVariance(unittest.TestCase):
+    def test_document_exists_and_is_open_target(self) -> None:
+        self.assertTrue(DOC.exists())
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("HW-OPEN-014", text)
+        self.assertIn("Coset Variance Theorem", text)
+        self.assertIn("does not prove the Coset Variance Theorem", text)
+
+    def test_q37_coset_partition_is_exact(self) -> None:
+        self.assertEqual(Q, 37)
+        self.assertEqual(len(subgroup_h(Q)), 3)
+        self.assertEqual(len(cosets(Q)), 12)
+        self.assertEqual(sum(len(c) for c in cosets(Q)), 36)
+        flattened = sorted(r for c in cosets(Q) for r in c)
+        self.assertEqual(flattened, list(unit_residues(Q)))
+
+    def test_coset_masses_partition_theta(self) -> None:
+        for depth in (2, 3):
+            self.assertAlmostEqual(sum(coset_masses(Q, depth)), theta_active(Q, depth), places=10)
+
+    def test_between_within_variances_are_positive_diagnostics(self) -> None:
+        rows = run_checks()
+        self.assertEqual([row.depth for row in rows], [2, 3, 4, 5])
+        for row in rows:
+            self.assertGreaterEqual(row.between_variance, 0.0)
+            self.assertGreaterEqual(row.within_variance, 0.0)
+            self.assertGreater(row.ratio, 0.0)
+
+    def test_direct_variance_functions_match_row(self) -> None:
+        for depth in (2, 3):
+            row = coset_variance_row(depth, Q)
+            self.assertAlmostEqual(row.between_variance, between_coset_variance(Q, depth), places=10)
+            self.assertAlmostEqual(row.within_variance, within_coset_variance(Q, depth), places=10)
+
+    def test_residue_masses_cover_unit_residues(self) -> None:
+        masses = residue_masses(Q, 2)
+        self.assertEqual(sorted(masses.keys()), list(unit_residues(Q)))
+
+    def test_theorem_remains_open(self) -> None:
+        unconditional_coset_variance_theorem_proved = False
+        closes_square_root_barrier = False
+        self.assertFalse(unconditional_coset_variance_theorem_proved)
+        self.assertFalse(closes_square_root_barrier)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_coset_variance.py
+++ b/tools/check_coset_variance.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Dict, Iterable, Tuple
+
+Q = 37
+BASE = 10
+
+
+@dataclass(frozen=True)
+class CosetVarianceRow:
+    q: int
+    depth: int
+    coset_count: int
+    orbit_size: int
+    theta_active: float
+    between_variance: float
+    within_variance: float
+    ratio: float
+
+
+@lru_cache(maxsize=None)
+def primes_upto(limit: int) -> Tuple[int, ...]:
+    sieve = bytearray(b"\x01") * (limit + 1)
+    sieve[0:2] = b"\x00\x00"
+    for p in range(2, int(limit**0.5) + 1):
+        if sieve[p]:
+            start = p * p
+            sieve[start : limit + 1 : p] = b"\x00" * (((limit - start) // p) + 1)
+    return tuple(i for i in range(limit + 1) if sieve[i])
+
+
+@lru_cache(maxsize=None)
+def primes_in_window(depth: int) -> Tuple[int, ...]:
+    low = 10 ** (depth - 1)
+    high = 10**depth
+    return tuple(p for p in primes_upto(high - 1) if low <= p < high)
+
+
+def ord_mod(base: int, q: int) -> int:
+    if math.gcd(base, q) != 1:
+        raise ValueError("base must be a unit")
+    x = 1
+    for k in range(1, q):
+        x = (x * base) % q
+        if x == 1:
+            return k
+    raise RuntimeError(q)
+
+
+def subgroup_h(q: int = Q, base: int = BASE) -> Tuple[int, ...]:
+    h = []
+    x = 1
+    for _ in range(ord_mod(base, q)):
+        h.append(x)
+        x = (x * base) % q
+    return tuple(h)
+
+
+def unit_residues(q: int = Q) -> Tuple[int, ...]:
+    return tuple(r for r in range(1, q) if math.gcd(r, q) == 1)
+
+
+def cosets(q: int = Q, base: int = BASE) -> Tuple[Tuple[int, ...], ...]:
+    h = set(subgroup_h(q, base))
+    seen = set()
+    out = []
+    for r in unit_residues(q):
+        if r in seen:
+            continue
+        c = tuple(sorted((r * x) % q for x in h))
+        out.append(c)
+        seen.update(c)
+    return tuple(out)
+
+
+def residue_masses(q: int, depth: int) -> Dict[int, float]:
+    masses = {r: 0.0 for r in unit_residues(q)}
+    for p in primes_in_window(depth):
+        residue = p % q
+        if residue != 0:
+            masses[residue] += math.log(p)
+    return masses
+
+
+def theta_active(q: int, depth: int) -> float:
+    return sum(math.log(p) for p in primes_in_window(depth) if p % q != 0)
+
+
+def coset_masses(q: int, depth: int) -> Tuple[float, ...]:
+    masses = residue_masses(q, depth)
+    return tuple(sum(masses[r] for r in c) for c in cosets(q))
+
+
+def between_coset_variance(q: int, depth: int) -> float:
+    values = coset_masses(q, depth)
+    mean = sum(values) / len(values)
+    return sum((v - mean) ** 2 for v in values)
+
+
+def within_coset_variance(q: int, depth: int) -> float:
+    masses = residue_masses(q, depth)
+    total = 0.0
+    for c in cosets(q):
+        mean = sum(masses[r] for r in c) / len(c)
+        total += sum((masses[r] - mean) ** 2 for r in c)
+    return total
+
+
+def coset_variance_row(depth: int, q: int = Q) -> CosetVarianceRow:
+    between = between_coset_variance(q, depth)
+    within = within_coset_variance(q, depth)
+    return CosetVarianceRow(
+        q=q,
+        depth=depth,
+        coset_count=len(cosets(q)),
+        orbit_size=len(subgroup_h(q)),
+        theta_active=theta_active(q, depth),
+        between_variance=between,
+        within_variance=within,
+        ratio=between / within if within else float("inf"),
+    )
+
+
+def coset_variance_rows(depths: Iterable[int] = (2, 3, 4, 5)) -> Tuple[CosetVarianceRow, ...]:
+    return tuple(coset_variance_row(depth) for depth in depths)
+
+
+def run_checks() -> Tuple[CosetVarianceRow, ...]:
+    assert len(subgroup_h(Q)) == 3
+    assert len(cosets(Q)) == 12
+    assert sum(len(c) for c in cosets(Q)) == 36
+    rows = coset_variance_rows()
+    for row in rows:
+        assert row.between_variance >= 0
+        assert row.within_variance >= 0
+        assert row.theta_active > 0
+    return rows
+
+
+if __name__ == "__main__":
+    for row in run_checks():
+        print(row)


### PR DESCRIPTION
Adds HW-OPEN-014 as the coset-variance theorem target plus q=37 coset variance diagnostics. Scope: open theorem target only; no RH/GRH proof and no unconditional variance bound.