### PR TITLE
prime-weil: add HW-PRIME-WEIL-017 quotient large-sieve diagnostic

### DIFF
--- a/docs/prime-operator-lane/HW-PRIME-WEIL-017-quotient-large-sieve.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-017-quotient-large-sieve.md
@@ -1,0 +1,156 @@
+# HW-PRIME-WEIL-017 — Quotient Large-Sieve Diagnostic
+
+Status: analytic-bound diagnostic / quotient-large-sieve target.  
+Claim class: method-grade diagnostic, not theorem-grade analytic progress.  
+Lane: prime/operator lane, quotient-character / coset-variance surface.  
+Depends on: `HW-OPEN-014`, `HW-PRIME-WEIL-016`.
+
+## Purpose
+
+This document tests the first analytic tool native to the coset-variance framework: applying a large-sieve-style estimate only to quotient characters of
+
+```text
+G_q / <10>.
+```
+
+These quotient characters are exactly the local non-cancelling characters. The goal is to determine whether the orbit/coset restriction improves the standard large-sieve scale enough to approach the GRH-scale packet bound.
+
+## Setup
+
+Let:
+
+```text
+G_q = (Z/qZ)^x,
+H_q = <10>,
+d_q = |H_q| = ord_q(10),
+I_q = [G_q:H_q] = (q-1)/d_q.
+```
+
+The non-cancelling local characters are the nontrivial characters of the quotient:
+
+```text
+G_q / H_q.
+```
+
+Their count is:
+
+```text
+n_nc(q) = I_q - 1.
+```
+
+The quotient restriction is meaningful because it discards all characters that see within-coset oscillation and keeps only characters that see between-coset mass imbalance.
+
+## Standard large-sieve scale
+
+A standard large-sieve comparison gives the model scale:
+
+```text
+B_standard(q,K) = (10^K + q^2) * sum_{p in W_K} (log p)^2.
+```
+
+This is a comparison scale, not a sharp theorem for this exact finite packet.
+
+## Quotient candidate scale
+
+The quotient-coset heuristic replaces the full unit group by the quotient size `I_q` and divides by the orbit size `d_q`:
+
+```text
+B_quotient(q,K) = (10^K / I_q + I_q) * sum_{p in W_K} (log p)^2 / d_q.
+```
+
+This captures the hoped-for gain from using the orbit structure.
+
+The quotient gain relative to the standard comparison is:
+
+```text
+B_standard / B_quotient.
+```
+
+For fixed q and large K, this gain is approximately:
+
+```text
+q - 1.
+```
+
+up to lower-order terms. This is a real finite structural improvement, but it is still a constant-factor improvement at fixed q.
+
+## GRH packet scale comparison
+
+A GRH-shaped packet scale for the non-cancelling local packet is:
+
+```text
+B_GRH(q,K) = n_nc(q) * 10^K * (log 10^K)^4.
+```
+
+The quotient diagnostic compares:
+
+```text
+B_quotient(q,K) / B_GRH(q,K).
+```
+
+If this ratio remains greater than 1 and grows with K, the quotient-large-sieve restriction has not crossed the square-root barrier.
+
+## Finite diagnostic results
+
+The diagnostic implementation is:
+
+```text
+tools/check_quotient_large_sieve.py
+```
+
+It evaluates q in:
+
+```text
+11, 13, 37
+```
+
+and depths:
+
+```text
+K = 3,4,5.
+```
+
+The CI guards require:
+
+- quotient improvement over the standard comparison for q=11,13,37;
+- quotient candidate scale still above the GRH packet scale at tested depths;
+- asymptotic gap factor increasing from K=5 to K=10 for q=37.
+
+## Result
+
+The quotient restriction gives a real structural improvement, but it does not close the GRH-scale gap.
+
+In the fixed-q regime, the gain is essentially a constant-factor gain from orbit/coset compression. The remaining obstruction still grows with the window scale.
+
+Thus the quotient large-sieve diagnostic supports the central conclusion of `HW-OPEN-014`:
+
+```text
+coset structure isolates the right packet,
+but standard large-sieve technology does not prove the Coset Variance Theorem.
+```
+
+## What would be needed to improve this
+
+A proof-closing result would need more than quotient restriction. It would need one of:
+
+1. a large-sieve inequality with a genuine square-root saving for fixed quotient packets;
+2. a dispersion estimate exploiting arithmetic structure of the cosets beyond quotient size;
+3. a cancellation theorem for coset mass imbalance across Richter windows;
+4. an explicit-formula tail bound that avoids assuming GRH;
+5. a new structural input not present in the standard large-sieve framework.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove the Coset Variance Theorem.
+
+This document does not prove an unconditional variance bound.
+
+This document does not prove the quotient candidate inequality as a sharp theorem.
+
+This document does not claim that quotient large sieve crosses the square-root barrier.
+
+This document does not close `HW-OPEN-014` or `HW-PRIME-WEIL-016`.

--- a/tests/test_quotient_large_sieve.py
+++ b/tests/test_quotient_large_sieve.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import unittest
+
+from tools.check_quotient_large_sieve import (
+    quotient_large_sieve_row,
+    run_checks,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "prime-operator-lane" / "HW-PRIME-WEIL-017-quotient-large-sieve.md"
+
+
+class TestQuotientLargeSieve(unittest.TestCase):
+    def test_document_exists_and_is_diagnostic(self) -> None:
+        self.assertTrue(DOC.exists())
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("HW-PRIME-WEIL-017", text)
+        self.assertIn("Quotient Large-Sieve Diagnostic", text)
+        self.assertIn("method-grade diagnostic", text)
+
+    def test_run_checks(self) -> None:
+        rows = run_checks()
+        self.assertTrue(rows)
+
+    def test_orbit_constants(self) -> None:
+        row11 = quotient_large_sieve_row(11, 5)
+        row13 = quotient_large_sieve_row(13, 5)
+        row37 = quotient_large_sieve_row(37, 5)
+        self.assertEqual((row11.orbit_size, row11.quotient_index, row11.noncancelling_count), (2, 5, 4))
+        self.assertEqual((row13.orbit_size, row13.quotient_index, row13.noncancelling_count), (6, 2, 1))
+        self.assertEqual((row37.orbit_size, row37.quotient_index, row37.noncancelling_count), (3, 12, 11))
+
+    def test_quotient_improves_standard_comparison(self) -> None:
+        for q in (11, 13, 37):
+            row = quotient_large_sieve_row(q, 5)
+            self.assertGreater(row.improvement_factor, 1.0)
+            self.assertLess(row.quotient_candidate_bound, row.standard_bound)
+
+    def test_quotient_bound_still_above_grh_packet_scale(self) -> None:
+        for q in (11, 13, 37):
+            row = quotient_large_sieve_row(q, 5)
+            self.assertGreater(row.quotient_to_grh_ratio, 1.0)
+
+    def test_gap_grows_with_depth_for_fixed_q37(self) -> None:
+        row5 = quotient_large_sieve_row(37, 5)
+        row10 = quotient_large_sieve_row(37, 10)
+        self.assertGreater(row10.asymptotic_gap_factor, row5.asymptotic_gap_factor)
+
+    def test_non_claims_are_present(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "does not prove RH",
+            "does not prove GRH",
+            "does not prove the Coset Variance Theorem",
+            "does not prove an unconditional variance bound",
+            "does not claim that quotient large sieve crosses the square-root barrier",
+        ]:
+            self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_quotient_large_sieve.py
+++ b/tools/check_quotient_large_sieve.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class QuotientLargeSieveRow:
+    q: int
+    depth: int
+    orbit_size: int
+    quotient_index: int
+    noncancelling_count: int
+    window_size: int
+    prime_log_square_sum: float
+    standard_bound: float
+    quotient_candidate_bound: float
+    improvement_factor: float
+    grh_packet_scale: float
+    quotient_to_grh_ratio: float
+    asymptotic_gap_factor: float
+
+
+def ord10(q: int) -> int:
+    if math.gcd(q, 10) != 1:
+        raise ValueError("q must be coprime to 10")
+    x = 1
+    for k in range(1, q):
+        x = (x * 10) % q
+        if x == 1:
+            return k
+    raise RuntimeError(q)
+
+
+@lru_cache(maxsize=None)
+def primes_upto(limit: int) -> Tuple[int, ...]:
+    sieve = bytearray(b"\x01") * (limit + 1)
+    sieve[0:2] = b"\x00\x00"
+    for p in range(2, int(limit**0.5) + 1):
+        if sieve[p]:
+            start = p * p
+            sieve[start : limit + 1 : p] = b"\x00" * (((limit - start) // p) + 1)
+    return tuple(i for i in range(limit + 1) if sieve[i])
+
+
+@lru_cache(maxsize=None)
+def primes_in_window(depth: int) -> Tuple[int, ...]:
+    low = 10 ** (depth - 1)
+    high = 10**depth
+    return tuple(p for p in primes_upto(high - 1) if low <= p < high)
+
+
+def prime_log_square_sum(depth: int) -> float:
+    return sum(math.log(p) ** 2 for p in primes_in_window(depth))
+
+
+def quotient_large_sieve_row(q: int, depth: int) -> QuotientLargeSieveRow:
+    d = ord10(q)
+    i = (q - 1) // d
+    nc = i - 1
+    n = 10**depth
+    s2 = prime_log_square_sum(depth)
+    standard = (n + q**2) * s2
+    quotient = ((n / i) + i) * s2 / d
+    improvement = standard / quotient
+    grh_packet = max(nc, 1) * n * math.log(n) ** 4
+    quotient_to_grh = quotient / grh_packet
+    asymptotic_gap = n / max((q - 1) * max(nc, 1) * math.log(n) ** 2, 1.0)
+    return QuotientLargeSieveRow(
+        q=q,
+        depth=depth,
+        orbit_size=d,
+        quotient_index=i,
+        noncancelling_count=nc,
+        window_size=n,
+        prime_log_square_sum=s2,
+        standard_bound=standard,
+        quotient_candidate_bound=quotient,
+        improvement_factor=improvement,
+        grh_packet_scale=grh_packet,
+        quotient_to_grh_ratio=quotient_to_grh,
+        asymptotic_gap_factor=asymptotic_gap,
+    )
+
+
+def quotient_large_sieve_rows(qs: Iterable[int] = (11, 13, 37), depths: Iterable[int] = (3, 4, 5)) -> Tuple[QuotientLargeSieveRow, ...]:
+    return tuple(quotient_large_sieve_row(q, depth) for q in qs for depth in depths)
+
+
+def run_checks() -> Tuple[QuotientLargeSieveRow, ...]:
+    rows = quotient_large_sieve_rows()
+    by_qd = {(row.q, row.depth): row for row in rows}
+    assert by_qd[(11, 5)].improvement_factor > 9.0
+    assert by_qd[(13, 5)].improvement_factor > 11.0
+    assert by_qd[(37, 5)].improvement_factor > 35.0
+    assert by_qd[(11, 5)].quotient_to_grh_ratio > 1.0
+    assert by_qd[(13, 5)].quotient_to_grh_ratio > 1.0
+    assert by_qd[(37, 5)].quotient_to_grh_ratio > 1.0
+    assert quotient_large_sieve_row(37, 10).asymptotic_gap_factor > quotient_large_sieve_row(37, 5).asymptotic_gap_factor
+    return rows
+
+
+if __name__ == "__main__":
+    for row in run_checks():
+        print(row)


### PR DESCRIPTION
Adds HW-PRIME-WEIL-017 as a quotient large-sieve diagnostic for non-cancelling quotient characters. Scope: method-grade diagnostic only; records constant-factor quotient improvement and remaining GRH-scale gap. No RH/GRH proof and no unconditional variance bound.