### PR TITLE
prime-weil: add HW-PRIME-WEIL-018 three locked gates status

### DIFF
--- a/docs/prime-operator-lane/HW-OPEN-015-operator-domain-self-adjointness.md
+++ b/docs/prime-operator-lane/HW-OPEN-015-operator-domain-self-adjointness.md
@@ -1,21 +1,27 @@
-# HW-OPEN-015 — Operator Domain and Essential Self-Adjointness Target
+# HW-OPEN-015 — Operator Domain and Normal Spectral-Radius Target
 
 Status: open operator-domain theorem target.  
-Claim class: finite operator facts plus infinite-domain obstruction map; not theorem-grade RH progress.  
+Claim class: finite normal-operator facts plus infinite-domain obstruction map; not theorem-grade RH progress.  
 Lane: prime/operator lane, Hilbert-Polya / operator-domain surface.  
 Depends on: `HW-PRIME-FINITE-OPERATOR-001`, `HW-OPEN-005`, `HW-PRIME-WEIL-017`.
 
 ## Purpose
 
-This document states Gate 3 of the Prime-Weil route: the operator-domain and essential-self-adjointness problem.
+This document states Gate 3 of the Prime-Weil route in corrected operator language.
 
-The finite operator has already been constructed and tested in:
+The earlier self-adjointness framing was too strong for the finite raw prime-residue operator. The finite convolution operator need not be self-adjoint because the raw prime-residue kernel need not satisfy:
 
 ```text
-tools/check_finite_character_operator.py
+A_K(h) = conjugate(A_K(h^{-1})).
 ```
 
-The finite result is not the proof. In finite dimension, an inversion-symmetric real convolution kernel gives a self-adjoint matrix. The real problem is the infinite/profinite completion and whether the limiting operator has a canonical self-adjoint realization whose spectral bounds imply the needed variance control.
+However, for finite abelian `G_P`, convolution operators are diagonalized by the character basis. Therefore the finite raw operator is normal:
+
+```text
+T_{P,K}^* T_{P,K} = T_{P,K} T_{P,K}^*.
+```
+
+The spectral theorem applies to normal operators. The proof gate is therefore not primarily self-adjointness. The proof gate is the spectral-radius/operator-norm bound.
 
 ## Finite operator surface
 
@@ -38,7 +44,7 @@ With the standard inner product on `l^2(G_P)`, the adjoint is convolution by the
 A_K^*(h) = conjugate(A_K(h^{-1})).
 ```
 
-Thus `T_{P,K}` is self-adjoint in finite dimension iff:
+The operator is self-adjoint iff:
 
 ```text
 A_K(h) = conjugate(A_K(h^{-1}))
@@ -46,11 +52,11 @@ A_K(h) = conjugate(A_K(h^{-1}))
 
 for all `h`.
 
-The existing finite diagnostic enforces this by replacing the raw kernel with its inversion-symmetric part.
+The raw finite kernel generally fails this condition, so the raw operator is generally not self-adjoint.
 
-## Finite spectral facts
+## Finite normality fact
 
-For finite abelian `G_P`, characters diagonalize convolution:
+For finite abelian `G_P`, every convolution operator is diagonalized by the finite character basis:
 
 ```text
 T_{P,K} chi = lambda_chi chi.
@@ -62,9 +68,33 @@ The eigenvalue is:
 lambda_chi = sum_{h in G_P} A_K(h) chi(h).
 ```
 
-If the kernel is real and inversion-symmetric, then the eigenvalues are real.
+Because the same unitary Fourier basis diagonalizes `T_{P,K}` and `T_{P,K}^*`, finite convolution is normal.
 
-This is finite linear algebra. It does not prove any zero-location statement.
+Therefore:
+
+```text
+||T_{P,K}|| = max_chi |lambda_chi|.
+```
+
+For the nontrivial restriction:
+
+```text
+||T_{P,K}^perp|| = max_{chi != 1} |psi_{W_K}(chi)|.
+```
+
+This is the exact finite operator reformulation of the character-sum barrier.
+
+## Correct Gate 3 statement
+
+The operator route asks for an unconditional spectral-radius bound:
+
+```text
+||T_{P,K}^perp|| = O(10^(K/2) K^A).
+```
+
+In the current lane, this is equivalent to GRH-strength square-root cancellation for the associated character sums.
+
+Thus the operator route is now a concrete normal-operator spectral-radius problem, not a vague Hilbert-Polya self-adjointness problem.
 
 ## Infinite completion target
 
@@ -84,7 +114,7 @@ The infinite operator target is a formal convolution operator:
 
 where `K` is the limiting arithmetic kernel obtained from prime-residue data after a specified regularization.
 
-## Domain problem
+## Domain and normality problem
 
 The key open problem is to define a dense domain:
 
@@ -96,33 +126,28 @@ such that:
 
 1. finite-cylinder functions lie in `D(T_infty)`;
 2. `T_infty D(T_infty) subset H_infty`;
-3. `T_infty` is symmetric on `D(T_infty)`;
+3. `T_infty` is closable;
 4. the adjoint `T_infty^*` is explicitly describable;
-5. deficiency indices can be computed or bounded;
-6. essential self-adjointness is proved or the obstruction is identified.
+5. the closure is normal, or the obstruction to normality is identified;
+6. a spectral-radius/operator-norm bound at GRH scale is proved or the obstruction is identified.
 
-## Why this matters
-
-If a canonical self-adjoint realization exists, then spectral radius and operator norm can be studied in a Hilbert-space framework rather than only through character-sum estimates.
-
-However, self-adjointness alone is not enough. A proof route would still need a norm bound of the right scale:
-
-```text
-||T_{P,K}^perp|| = O(10^(K/2) poly(K)).
-```
-
-That bound is GRH-strength unless the operator structure supplies a new positivity or compactness mechanism.
+Essential self-adjointness may still be useful for a symmetrized or transformed operator, but it is not the primary finite operator fact.
 
 ## Current obstruction
 
-The finite operator is self-adjoint after symmetrization, but the infinite kernel is not currently known to define a bounded or essentially self-adjoint operator on the proposed completion.
+The finite operator is normal and explicitly diagonalized. This does not close the proof because the spectral-radius bound remains exactly the character-sum bound:
 
-The obstruction is analytic:
+```text
+max_{chi != 1} |psi_{W_K}(chi)| = O(10^(K/2) K^A).
+```
+
+The infinite obstruction is analytic:
 
 - growth of the limiting kernel;
 - choice of regularization;
 - domain stability;
-- adjoint-domain equality;
+- adjoint-domain control;
+- normality of the closure;
 - spectral-radius bounds strong enough to imply the variance estimate.
 
 ## Non-claims
@@ -133,7 +158,9 @@ This document does not prove GRH.
 
 This document does not construct a Hilbert-Polya operator.
 
-This document does not prove essential self-adjointness of `T_infty`.
+This document does not prove normality of an infinite limiting operator.
+
+This document does not prove essential self-adjointness of any infinite operator.
 
 This document does not prove an operator-norm bound at GRH scale.
 

--- a/docs/prime-operator-lane/HW-PRIME-WEIL-018-three-locked-gates.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-018-three-locked-gates.md
@@ -1,0 +1,137 @@
+# HW-PRIME-WEIL-018 — Three Locked Gates: Current Status
+
+Status: consolidated proof-gate status document.  
+Claim class: barrier summary / roadmap, not theorem-grade RH progress.  
+Lane: prime/operator lane, current-state synthesis.  
+Depends on: `HW-OPEN-014`, `HW-PRIME-WEIL-016`, `HW-PRIME-WEIL-017`, `HW-OPEN-015`.
+
+## Purpose
+
+This document records the current state of the Prime-Weil route after the quotient large-sieve diagnostic, explicit-formula surrogate, and corrected operator-domain analysis.
+
+The program has produced a precise finite reformulation and diagnostic apparatus. It has not produced a proof of RH or GRH.
+
+The remaining proof problem is now organized as three locked gates.
+
+## Gate 1 — Coset Variance Theorem
+
+Target:
+
+```text
+Var_between(q,K) / Var_within(q,K) = O(K^A)
+```
+
+for the relevant coset quotient packets.
+
+Current obstruction: between-coset variance must converge at square-root scale. This is the prime-race/coset-equidistribution obstruction.
+
+Best current diagnostic: quotient large-sieve restriction. It gives a real orbit/coset improvement but does not cross the square-root barrier.
+
+Summary:
+
+| Item | Status |
+|---|---|
+| Surface | `HW-OPEN-014` |
+| Tool tried | standard large sieve, quotient large sieve |
+| Best gain | finite constant-factor quotient/orbit improvement |
+| Remaining gap | grows with `K`; GRH-scale square-root cancellation not reached |
+| Next tools | Selberg/dispersion over quotient packets; pretentious distance; coset prime-race analysis |
+
+The quotient large sieve isolates the right packet, but standard large-sieve technology does not prove the Coset Variance Theorem.
+
+## Gate 2 — Explicit Formula Packet-Energy Surrogate
+
+Target:
+
+```text
+E_C(K) = (1/|C|) sum_{chi in C} |psi_{W_K}(chi)|^2
+```
+
+expressed through zero sums with controlled truncation error.
+
+Current obstruction: truncation height grows too quickly.
+
+Summary:
+
+| K | Required height | Current verification scale | Status |
+|---:|---:|---:|---|
+| 5 | about `4e4` | about `3e12` | feasible |
+| 10 | about `5e7` | about `3e12` | feasible |
+| 20 | about `2e13` | about `3e12` | borderline/no |
+| 50 | about `1e29` | about `3e12` | no |
+| 11088 | about `10^5544` | about `3e12` | impossible |
+
+The explicit-formula surrogate is useful for finite verification. It does not reach the resonant tower depth with current zero verification heights.
+
+Next tools:
+
+1. zero-table wiring for finite verification;
+2. smoothed windows;
+3. zero-density estimates;
+4. off-diagonal cancellation bounds;
+5. explicit tail estimates that do not assume GRH.
+
+## Gate 3 — Operator Spectral Radius
+
+Corrected finite operator fact: the raw finite convolution operator is normal, not necessarily self-adjoint.
+
+For finite abelian `G_P`, characters diagonalize convolution:
+
+```text
+T_{P,K} chi = lambda_chi chi.
+```
+
+Therefore the finite operator is normal and the spectral theorem applies. The finite spectral radius is:
+
+```text
+||T_{P,K}^perp|| = max_{chi != 1} |psi_{W_K}(chi)|.
+```
+
+The correct Gate 3 target is the operator-norm / spectral-radius bound:
+
+```text
+||T_{P,K}^perp|| = O(10^(K/2) K^A).
+```
+
+This is exactly the character-sum square-root bound in operator language.
+
+Summary:
+
+| Item | Status |
+|---|---|
+| Surface | `HW-OPEN-015` |
+| Finite operator | normal convolution operator on `l^2(G_P)` |
+| Spectral theorem | applies in finite dimension |
+| Obstruction | spectral-radius bound remains GRH-strength |
+| Infinite target | define `T_infty` on `L^2(Z_hat^x, d mu_Haar)` or restricted completion |
+| Next tools | domain/closure analysis; normality of closure; random matrix/GUE spectral heuristics; norm estimates |
+
+Self-adjointness may be useful for a symmetrized operator, but it is not the core finite fact. The core finite fact is normality; the proof barrier is the spectral-radius estimate.
+
+## Current conclusion
+
+All three gates are precisely stated and remain locked.
+
+1. Coset variance: quotient large sieve gives a real but insufficient gain.
+2. Explicit formula: finite verification works only below the truncation barrier.
+3. Operator route: finite normality is exact, but the spectral-radius bound is still GRH-strength.
+
+The framework is a precise finite reformulation and diagnostic apparatus for the GRH barrier. It is not a proof.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove the Coset Variance Theorem.
+
+This document does not prove the explicit-formula surrogate closes the truncation barrier.
+
+This document does not construct a Hilbert-Polya operator.
+
+This document does not prove an operator-norm bound at GRH scale.
+
+This document does not prove an unconditional variance bound.
+
+This document does not close the square-root barrier.

--- a/tests/test_operator_domain_self_adjointness.py
+++ b/tests/test_operator_domain_self_adjointness.py
@@ -4,6 +4,9 @@ import unittest
 from tools.check_finite_character_operator import (
     MODULUS,
     TOLERANCE,
+    build_dlog_table,
+    character_indices,
+    eigenvalue_for_character,
     inversion_symmetric_kernel,
     kernel_is_inversion_symmetric,
     raw_prime_residue_kernel,
@@ -19,20 +22,31 @@ def max_adjoint_error(kernel, modulus=MODULUS):
     return max(abs(kernel[h] - kernel[pow(h, -1, modulus)]) for h in kernel)
 
 
+def finite_spectral_radius(kernel) -> float:
+    dlog = build_dlog_table()
+    return max(abs(eigenvalue_for_character(index, kernel, dlog)) for index in character_indices())
+
+
 class TestOperatorDomainSelfAdjointness(unittest.TestCase):
     def test_document_exists_and_is_open_target(self) -> None:
         self.assertTrue(DOC.exists())
         text = DOC.read_text(encoding="utf-8")
         self.assertIn("HW-OPEN-015", text)
-        self.assertIn("Operator Domain and Essential Self-Adjointness Target", text)
-        self.assertIn("does not prove essential self-adjointness", text)
+        self.assertIn("Operator Domain and Normal Spectral-Radius Target", text)
+        self.assertIn("does not prove normality of an infinite limiting operator", text)
 
-    def test_finite_kernel_adjoint_criterion(self) -> None:
+    def test_raw_kernel_not_self_adjoint_but_symmetrized_kernel_is(self) -> None:
         raw = raw_prime_residue_kernel()
         sym = inversion_symmetric_kernel()
         self.assertGreater(max_adjoint_error(raw), TOLERANCE)
         self.assertLessEqual(max_adjoint_error(sym), TOLERANCE)
         self.assertTrue(kernel_is_inversion_symmetric(sym))
+
+    def test_finite_convolution_has_character_spectral_radius(self) -> None:
+        raw = raw_prime_residue_kernel()
+        sym = inversion_symmetric_kernel()
+        self.assertGreater(finite_spectral_radius(raw), 0.0)
+        self.assertGreater(finite_spectral_radius(sym), 0.0)
 
     def test_finite_dimension_is_48_for_p210(self) -> None:
         self.assertEqual(len(reduced_residues(MODULUS)), 48)
@@ -42,9 +56,9 @@ class TestOperatorDomainSelfAdjointness(unittest.TestCase):
         for token in [
             "L^2(Z_hat^x, d mu_Haar)",
             "D(T_infty)",
-            "deficiency indices",
-            "essential self-adjointness",
-            "operator-norm bound",
+            "closure is normal",
+            "spectral-radius/operator-norm bound",
+            "max_{chi != 1} |psi_{W_K}(chi)|",
         ]:
             self.assertIn(token, text)
 

--- a/tests/test_three_locked_gates.py
+++ b/tests/test_three_locked_gates.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "prime-operator-lane" / "HW-PRIME-WEIL-018-three-locked-gates.md"
+
+
+class TestThreeLockedGates(unittest.TestCase):
+    def test_document_exists_and_is_status_surface(self) -> None:
+        self.assertTrue(DOC.exists())
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("HW-PRIME-WEIL-018", text)
+        self.assertIn("Three Locked Gates", text)
+        self.assertIn("barrier summary / roadmap", text)
+
+    def test_three_gates_are_present(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "Gate 1 — Coset Variance Theorem",
+            "Gate 2 — Explicit Formula Packet-Energy Surrogate",
+            "Gate 3 — Operator Spectral Radius",
+        ]:
+            self.assertIn(token, text)
+
+    def test_operator_gate_uses_normal_spectral_radius_not_self_adjoint_core(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "raw finite convolution operator is normal, not necessarily self-adjoint",
+            "||T_{P,K}^perp|| = max_{chi != 1} |psi_{W_K}(chi)|",
+            "Self-adjointness may be useful for a symmetrized operator, but it is not the core finite fact",
+        ]:
+            self.assertIn(token, text)
+
+    def test_explicit_formula_barrier_is_pinned(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in ["11088", "10^5544", "impossible", "truncation barrier"]:
+            self.assertIn(token, text)
+
+    def test_quotient_large_sieve_obstruction_is_pinned(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "quotient large sieve gives a real but insufficient gain",
+            "standard large-sieve technology does not prove the Coset Variance Theorem",
+        ]:
+            self.assertIn(token, text)
+
+    def test_non_claims_are_present(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "does not prove RH",
+            "does not prove GRH",
+            "does not prove the Coset Variance Theorem",
+            "does not construct a Hilbert-Polya operator",
+            "does not close the square-root barrier",
+        ]:
+            self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Updates HW-OPEN-015 to the corrected normal-operator spectral-radius framing and adds HW-PRIME-WEIL-018 as the three locked gates status document. Scope: barrier summary and operator-framing correction only; no RH/GRH proof, no Hilbert-Polya construction, and no unconditional variance bound.