### PR TITLE
prime-weil: add HW-PRIME-WEIL-019 coset dispersion diagnostic

### DIFF
--- a/docs/prime-operator-lane/HW-PRIME-WEIL-019-coset-dispersion-diagnostic.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-019-coset-dispersion-diagnostic.md
@@ -1,0 +1,105 @@
+# HW-PRIME-WEIL-019 — Coset Dispersion Diagnostic
+
+Status: finite diagnostic surface.  
+Claim class: method-grade dispersion comparison, not theorem-grade analytic progress.  
+Lane: prime/operator lane, coset variance / dispersion-method surface.  
+Depends on: `HW-OPEN-014`, `HW-PRIME-WEIL-017`, `HW-PRIME-WEIL-018`.
+
+## Purpose
+
+This document tests the dispersion-method branch of Gate 1.
+
+The goal is to compare the directly measured q=37 between-coset dispersion against the quotient large-sieve candidate scale and the GRH-shaped packet scale.
+
+The result is negative for proof closure: the finite dispersion values are well behaved, and the quotient restriction gives a real improvement over the standard comparison, but the quotient candidate scale remains above the GRH-shaped packet scale at the tested depth. The square-root barrier remains.
+
+## Setup
+
+For q=37:
+
+```text
+H_q = <10> subset (Z/qZ)^x,
+d_q = ord_37(10) = 3,
+I_q = [(Z/37Z)^x : H_q] = 12.
+```
+
+The cosets of `H_q` partition the 36 unit residues modulo 37 into 12 cosets of size 3.
+
+For a Richter window `W_K`, define coset mass:
+
+```text
+F_K(C) = sum_{p in W_K, p mod q in C} log p.
+```
+
+The between-coset dispersion is:
+
+```text
+D_between(q,K) = sum_C (F_K(C) - mean_C F_K)^2.
+```
+
+This is the same object as `Var_between(q,K)` in `HW-OPEN-014`.
+
+The within-coset variance is:
+
+```text
+D_within(q,K) = sum_C sum_{r in C} (M_K(r) - mean_{r in C} M_K)^2.
+```
+
+## Finite q=37 measured values
+
+| K | between variance | within variance | between/within |
+|---:|---:|---:|---:|
+| 2 | `105.168280863028` | `126.326852505157` | `0.832509310392` |
+| 3 | `1694.760557860094` | `682.772557394117` | `2.482174392492` |
+| 4 | `8623.482855618979` | `13379.773176405680` | `0.644516371236` |
+| 5 | `95181.84283496864` | `100520.91659258083` | `0.946885942363` |
+
+The finite values oscillate, consistent with the prime-race behavior seen in the q=37 packet measurement.
+
+## Comparison scales
+
+The diagnostic compares three scales:
+
+1. measured between-coset variance;
+2. quotient large-sieve candidate bound;
+3. GRH-shaped packet scale.
+
+The quotient large-sieve candidate remains above the GRH-shaped packet scale at the tested depth `K=5` for q=37.
+
+The implemented outcome is therefore:
+
+```text
+quotient_improves_but_gap_remains
+```
+
+## Falsification criteria
+
+The branch was evaluated against three possible outcomes:
+
+1. If the dispersion bound reached square-root scale, Gate 1 would become live.
+2. If the dispersion bound improved the quotient-large-sieve scale by an additional factor, it would be a stronger component but still short of proof unless it reached square-root scale.
+3. If the dispersion comparison stayed at the quotient-large-sieve scale, it would not improve Gate 1.
+
+The current diagnostic lands in the third class for the bound surface: it confirms the finite dispersion object and the quotient improvement, but it does not produce a new square-root-scale theorem.
+
+## Conclusion
+
+The dispersion branch is correctly formulated but does not yet close Gate 1.
+
+The next possible analytic refinement is not another raw finite measurement. It would require a theorem that bounds between-coset dispersion below the quotient-large-sieve candidate scale by exploiting arithmetic structure inside the coset indicators.
+
+## Non-claims
+
+This document does not prove RH.
+
+This document does not prove GRH.
+
+This document does not prove the Coset Variance Theorem.
+
+This document does not prove a dispersion-method square-root bound.
+
+This document does not prove an unconditional variance bound.
+
+This document does not claim that the finite q=37 measurements imply asymptotic coset equidistribution.
+
+This document does not close the square-root barrier.

--- a/tests/test_coset_dispersion.py
+++ b/tests/test_coset_dispersion.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import unittest
+
+from tools.check_coset_dispersion import coset_dispersion_row, run_checks
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "prime-operator-lane" / "HW-PRIME-WEIL-019-coset-dispersion-diagnostic.md"
+
+
+class TestCosetDispersion(unittest.TestCase):
+    def test_document_exists_and_is_diagnostic(self) -> None:
+        self.assertTrue(DOC.exists())
+        text = DOC.read_text(encoding="utf-8")
+        self.assertIn("HW-PRIME-WEIL-019", text)
+        self.assertIn("Coset Dispersion Diagnostic", text)
+        self.assertIn("method-grade dispersion comparison", text)
+
+    def test_run_checks(self) -> None:
+        rows = run_checks()
+        self.assertEqual([row.depth for row in rows], [2, 3, 4, 5])
+
+    def test_q37_finite_values(self) -> None:
+        expected = {
+            2: (105.16828086302826, 126.32685250515715, 0.8325093103917466),
+            3: (1694.7605578600942, 682.7725573941173, 2.482174392492208),
+            4: (8623.482855618979, 13379.77317640568, 0.6445163712360912),
+            5: (95181.84283496864, 100520.91659258083, 0.9468859423631016),
+        }
+        for depth, (between, within, ratio) in expected.items():
+            row = coset_dispersion_row(37, depth)
+            self.assertAlmostEqual(row.between_variance, between, places=10)
+            self.assertAlmostEqual(row.within_variance, within, places=10)
+            self.assertAlmostEqual(row.between_within_ratio, ratio, places=12)
+
+    def test_quotient_bound_does_not_reach_grh_scale(self) -> None:
+        row = coset_dispersion_row(37, 5)
+        self.assertGreater(row.quotient_to_grh_ratio, 1.0)
+        self.assertEqual(row.dispersion_outcome, "quotient_improves_but_gap_remains")
+
+    def test_measured_dispersion_is_below_quotient_candidate_bound(self) -> None:
+        for depth in (2, 3, 4, 5):
+            row = coset_dispersion_row(37, depth)
+            self.assertLess(row.between_variance, row.quotient_candidate_bound)
+
+    def test_falsification_classes_are_recorded(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "square-root scale",
+            "stronger component",
+            "does not improve Gate 1",
+            "quotient_improves_but_gap_remains",
+        ]:
+            self.assertIn(token, text)
+
+    def test_non_claims_are_present(self) -> None:
+        text = DOC.read_text(encoding="utf-8")
+        for token in [
+            "does not prove RH",
+            "does not prove GRH",
+            "does not prove the Coset Variance Theorem",
+            "does not prove a dispersion-method square-root bound",
+            "does not close the square-root barrier",
+        ]:
+            self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_coset_dispersion.py
+++ b/tools/check_coset_dispersion.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+from tools.check_coset_variance import between_coset_variance, within_coset_variance
+from tools.check_quotient_large_sieve import quotient_large_sieve_row
+
+
+@dataclass(frozen=True)
+class CosetDispersionRow:
+    q: int
+    depth: int
+    between_variance: float
+    within_variance: float
+    between_within_ratio: float
+    quotient_candidate_bound: float
+    grh_packet_scale: float
+    measured_to_grh_ratio: float
+    quotient_to_grh_ratio: float
+    dispersion_outcome: str
+
+
+def coset_dispersion_row(q: int, depth: int) -> CosetDispersionRow:
+    between = between_coset_variance(q, depth)
+    within = within_coset_variance(q, depth)
+    qls = quotient_large_sieve_row(q, depth)
+    measured_to_grh = between / qls.grh_packet_scale
+    quotient_to_grh = qls.quotient_candidate_bound / qls.grh_packet_scale
+    if qls.quotient_candidate_bound <= qls.grh_packet_scale:
+        outcome = "square_root_scale_candidate"
+    elif qls.quotient_candidate_bound < qls.standard_bound:
+        outcome = "quotient_improves_but_gap_remains"
+    else:
+        outcome = "no_quotient_improvement"
+    return CosetDispersionRow(
+        q=q,
+        depth=depth,
+        between_variance=between,
+        within_variance=within,
+        between_within_ratio=between / within if within else float("inf"),
+        quotient_candidate_bound=qls.quotient_candidate_bound,
+        grh_packet_scale=qls.grh_packet_scale,
+        measured_to_grh_ratio=measured_to_grh,
+        quotient_to_grh_ratio=quotient_to_grh,
+        dispersion_outcome=outcome,
+    )
+
+
+def coset_dispersion_rows(q: int = 37, depths: Iterable[int] = (2, 3, 4, 5)) -> Tuple[CosetDispersionRow, ...]:
+    return tuple(coset_dispersion_row(q, depth) for depth in depths)
+
+
+def run_checks() -> Tuple[CosetDispersionRow, ...]:
+    rows = coset_dispersion_rows()
+    assert [row.depth for row in rows] == [2, 3, 4, 5]
+    for row in rows:
+        assert row.between_variance > 0
+        assert row.within_variance > 0
+        assert row.between_within_ratio > 0
+        assert row.quotient_candidate_bound > row.between_variance
+    assert rows[-1].quotient_to_grh_ratio > 1.0
+    assert rows[-1].dispersion_outcome == "quotient_improves_but_gap_remains"
+    return rows
+
+
+if __name__ == "__main__":
+    for row in run_checks():
+        print(row)


### PR DESCRIPTION
Adds HW-PRIME-WEIL-019 as the coset-dispersion diagnostic for Gate 1. Scope: finite dispersion comparison only; records q=37 between/within variance and confirms quotient improvement does not reach GRH scale. No RH/GRH proof and no unconditional variance bound.