### PR TITLE
HW-PRIME-WEIL-009 dimension-coordinate bridge registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ The repository also develops an auditable operator framework for prime-distribut
 
 The current prime residual manuscript scaffold is captured in `docs/prime-operator-lane/prime-residual-manuscript-scaffold-v0.1.md`. It locks the density/intensity correction `dπ/dx ~ 1/log x` versus `dπ/du ~ e^u/u`, keeps `e^(u/2)` language as an RH-shaped diagnostic only, and defines the manuscript spine for operator ordering, residual channels, harness protocol, claim ledger, figure semantics, and publication voice.
 
+HW-PRIME-WEIL-009 registers the reciprocal dimension-coordinate bridge to `SocioProphet/Heller-Godel`: the HW-PRIME-WEIL-008 circle/hyperbola boundary is paired with the representation-theoretic `dim rho = 1` unit-circle locus in HG-MTH-008.6. This is an analogy of boundary position only; `dim rho` is never equal to the HW off-critical-line parameter delta.
+
 The companion governance artifacts are:
 
 - `docs/prime-operator-lane/operator-registry-v0.1.md` — typed operator registry for coordinate maps, filters, channels, scores, observables, residuals, certificates, controls, and perturbations.

--- a/docs/prime-operator-lane/HW-PRIME-WEIL-009-dimension-coordinate.md
+++ b/docs/prime-operator-lane/HW-PRIME-WEIL-009-dimension-coordinate.md
@@ -1,0 +1,52 @@
+# HW-PRIME-WEIL-009 — Dimension-Coordinate Bridge
+
+Status: reciprocal registration / bridge stub.  
+Primary home: `SocioProphet/Heller-Godel`, `docs/claims/HG-MTH-008.6-dimension-spectrum-bridge.md`.  
+Parent: HW-PRIME-WEIL-008 geometric chain — circle/hyperbola tangency, `delta=0` critical-line boundary.  
+Date: 2026-05-28
+
+## Purpose
+
+This stub registers the Heller-Godel dimension-spectrum bridge from the Heller-Winters side.
+
+HG-MTH-008.6 identifies `dim rho = chi(e)` as the representation-theoretic coordinate for the same boundary that HW-PRIME-WEIL-008 describes geometrically as the unit-circle / unit-hyperbola tangency. Under this registration, the `dim rho = 1` locus is the representation-theoretic unit-circle boundary; `dim rho > 1` is the discrete off-circle departure.
+
+## Boundary discipline
+
+The `delta` parameter from HW-PRIME-WEIL-008 is the continuous off-critical-line / hyperbolic departure coordinate. The representation-theoretic displacement `dim rho - 1` is a discrete radial-displacement analogue.
+
+These are analogous boundary-position coordinates only. They are not equal quantities.
+
+Forbidden overclaim:
+
+```text
+dim rho = delta
+```
+
+Any artifact asserting that equality is defective.
+
+## Registration statement
+
+The bridge reads:
+
+```text
+dim rho = 1       <-> unit-circle / abelian / Fourier-easy boundary
+
+dim rho > 1       <-> off-circle / non-abelian / hard-frontier departure
+
+delta = 0         <-> HW-PRIME-WEIL-008 tangency / critical-line boundary
+
+delta > 0         <-> HW-PRIME-WEIL-008 hyperbolic departure
+```
+
+The correspondence is by position relative to the boundary, not by numerical equality.
+
+## Non-claims
+
+This stub does not prove RH, GRH, Artin, P vs NP, or any complexity-class separation. It does not promote the HW-PRIME-WEIL-008 geometric chain beyond its existing claim boundary. It does not implement GCT orbit-closure machinery. It only registers the reciprocal pointer to the Heller-Godel primary claim.
+
+## Crosslinks
+
+- Primary claim: `SocioProphet/Heller-Godel/docs/claims/HG-MTH-008.6-dimension-spectrum-bridge.md`
+- Heller-Godel concept note: `SocioProphet/Heller-Godel/docs/concepts/dimension-spectrum-coordinate.md`
+- Heller-Winters parent: HW-PRIME-WEIL-008 geometric chain


### PR DESCRIPTION
## Summary

Registers the reciprocal Heller-Winters side of the HG-MTH-008.6 dimension-spectrum bridge.

Adds:

- `docs/prime-operator-lane/HW-PRIME-WEIL-009-dimension-coordinate.md`
- README crosslink under the prime/operator lane

## Claim discipline

This PR only registers the bridge pointer. It does not promote HW-PRIME-WEIL-008 beyond its existing geometric-chain boundary.

The central guard is explicit:

- `dim rho - 1` is a discrete representation-theoretic radial-displacement analogue;
- `delta` is the continuous HW off-critical-line / hyperbolic departure coordinate;
- the relation is analogy of boundary position only;
- `dim rho = delta` is forbidden.

## Non-claims

This PR does not prove RH, GRH, Artin, P vs NP, or any complexity-class separation. It does not implement GCT orbit-closure machinery. It only registers the reciprocal pointer to `SocioProphet/Heller-Godel/docs/claims/HG-MTH-008.6-dimension-spectrum-bridge.md`.