### PR TITLE
Declare Heller-Godel PFK authority in proof adapter

### DIFF
--- a/proof-adapter.json
+++ b/proof-adapter.json
@@ -3,6 +3,23 @@
   "repo": "SocioProphet/Heller-Winters-Theorem",
   "domain": "su2-finite-channel-representation-theory and finite-window prime-distribution instrumentation",
   "controller_protocol": "protocol/proof-apparatus-workspace/v0",
+  "pfk_authority": {
+    "authority_repo": "SocioProphet/Heller-Godel",
+    "authority_path": "proof_fabric_kernel/",
+    "pinned_commit": "4c8560dfc347346f17b1dd045082db55968d0d4f",
+    "consumed_schemas": [
+      "PFK-SCHEMA-001",
+      "PFK-SCHEMA-002",
+      "PFK-SCHEMA-003",
+      "PFK-SCHEMA-004"
+    ],
+    "consumer_maturity": "M1-pinned-schema-dependency",
+    "local_schema_authority": false,
+    "schema_validity_is_content_validity": false,
+    "notes": [
+      "PFK envelope validity is not RH evidence, continuum evidence, finite-channel theorem evidence, or Heller-Winters theorem evidence."
+    ]
+  },
   "claims": [
     {
       "claim_id": "HW-LOGVOLUME-001",


### PR DESCRIPTION
## Summary

Adds the Sociosphere-compatible `pfk_authority` block to `proof-adapter.json`.

The adapter now declares:

- `authority_repo`: `SocioProphet/Heller-Godel`
- `authority_path`: `proof_fabric_kernel/`
- pinned Heller-Godel commit: `4c8560dfc347346f17b1dd045082db55968d0d4f`
- consumed schemas: `PFK-SCHEMA-001` through `PFK-SCHEMA-004`
- `local_schema_authority: false`
- `schema_validity_is_content_validity: false`

## Boundary

This does not promote any Heller-Winters, RH, GRH, finite-channel, arithmetic-volume, or continuum claim. PFK envelope validity remains envelope validity only.